### PR TITLE
Sync marketplace releases through PRs

### DIFF
--- a/.github/workflows/release-sync.yml
+++ b/.github/workflows/release-sync.yml
@@ -15,6 +15,7 @@ jobs:
     permissions:
       contents: read
     env:
+      MARKETPLACE_REPO: sendbird/codex-plugins
       RELEASE_TAG: ${{ github.event.release.tag_name || inputs.release_tag || github.ref_name }}
     steps:
       - uses: actions/checkout@v6
@@ -30,19 +31,49 @@ jobs:
         with:
           repository: sendbird/codex-plugins
           path: marketplace
-          ssh-key: ${{ secrets.CODEX_PLUGINS_DEPLOY_KEY }}
+          token: ${{ secrets.CODEX_PLUGINS_GH_TOKEN }}
           persist-credentials: true
       - name: Sync marketplace contents
         run: node scripts/sync-marketplace-release.mjs marketplace
-      - name: Commit and push
+      - name: Commit, push, and open marketplace PR
+        id: sync_pr
+        env:
+          GH_TOKEN: ${{ secrets.CODEX_PLUGINS_GH_TOKEN }}
         run: |
+          set -euo pipefail
+          BRANCH="release-sync/${RELEASE_TAG//\//-}"
+          TITLE="Sync cc release ${RELEASE_TAG}"
+          BODY=$'Automated sync for '"${RELEASE_TAG}"$' from sendbird/cc-plugin-codex.\n\nSource release: https://github.com/sendbird/cc-plugin-codex/releases/tag/'"${RELEASE_TAG}"
           cd marketplace
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git checkout -B "$BRANCH"
           git add .
           if git diff --cached --quiet; then
             echo "No marketplace changes to push."
+            echo "changed=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          git commit -m "Sync cc release ${RELEASE_TAG}"
-          git push origin HEAD:main
+          git commit -m "$TITLE"
+          git push --force --set-upstream origin "$BRANCH"
+          echo "changed=true" >> "$GITHUB_OUTPUT"
+          echo "branch=$BRANCH" >> "$GITHUB_OUTPUT"
+
+          PR_NUMBER="$(gh pr list --repo "$MARKETPLACE_REPO" --state open --head "$BRANCH" --base main --json number --jq '.[0].number // empty')"
+          if [ -n "$PR_NUMBER" ]; then
+            gh pr edit "$PR_NUMBER" --repo "$MARKETPLACE_REPO" --title "$TITLE" --body "$BODY"
+          else
+            gh pr create --repo "$MARKETPLACE_REPO" --base main --head "$BRANCH" --title "$TITLE" --body "$BODY" >/dev/null
+            PR_NUMBER="$(gh pr view "$BRANCH" --repo "$MARKETPLACE_REPO" --json number --jq .number)"
+          fi
+          echo "pr_number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
+      - name: Merge marketplace PR
+        if: steps.sync_pr.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.CODEX_PLUGINS_GH_TOKEN }}
+        run: |
+          gh pr merge "${{ steps.sync_pr.outputs.pr_number }}" \
+            --repo "$MARKETPLACE_REPO" \
+            --squash \
+            --delete-branch \
+            --admin


### PR DESCRIPTION
## Summary
- stop trying to push directly to the protected main branch of sendbird/codex-plugins
- push a release-specific branch, open or update a marketplace PR, and admin-merge it
- switch the workflow to use a cross-repo GitHub token and keep the manual release_tag retry path

## Testing
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release-sync.yml"); puts "ok"'
- git diff --check -- .github/workflows/release-sync.yml
