### PR TITLE
Wait for marketplace checks before merge

### DIFF
--- a/.github/workflows/release-sync.yml
+++ b/.github/workflows/release-sync.yml
@@ -72,6 +72,11 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.CODEX_PLUGINS_GH_TOKEN }}
         run: |
+          gh pr checks "${{ steps.sync_pr.outputs.pr_number }}" \
+            --repo "$MARKETPLACE_REPO" \
+            --watch \
+            --interval 10
+
           gh pr merge "${{ steps.sync_pr.outputs.pr_number }}" \
             --repo "$MARKETPLACE_REPO" \
             --squash \


### PR DESCRIPTION
## Summary
- wait for marketplace PR checks to finish before trying the admin merge
- keep the release sync flow fully automated for protected codex-plugins main

## Testing
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release-sync.yml"); puts "ok"'
- git diff --check -- .github/workflows/release-sync.yml
