### PR TITLE
Add npm trusted publishing workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,26 @@
+name: Publish to npm
+
+on:
+  release:
+    types:
+      - published
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.release.tag_name }}
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: npm
+          registry-url: "https://registry.npmjs.org"
+      - run: npm ci
+      - run: npm run check
+      - run: npm pack --dry-run
+      - run: npm publish

--- a/package.json
+++ b/package.json
@@ -11,13 +11,16 @@
   "homepage": "https://github.com/sendbird/cc-plugin-codex",
   "repository": {
     "type": "git",
-    "url": "https://github.com/sendbird/cc-plugin-codex.git"
+    "url": "git+https://github.com/sendbird/cc-plugin-codex.git"
   },
   "bin": "scripts/installer-cli.mjs",
   "bugs": {
     "url": "https://github.com/sendbird/cc-plugin-codex/issues"
   },
   "license": "Apache-2.0",
+  "publishConfig": {
+    "access": "public"
+  },
   "files": [
     ".codex-plugin",
     "CHANGELOG.md",


### PR DESCRIPTION
## Summary
- add a release-published GitHub Actions workflow for npm trusted publishing
- grant the workflow  so npm can verify the OIDC identity
- set npm package publish metadata for public publish and normalized repository URL

## Testing
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/publish.yml"); puts "ok"'
- npm pack --dry-run
- git diff --check -- package.json .github/workflows/publish.yml
