### PR TITLE
Allow manual npm publish workflow runs

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,6 +4,12 @@ on:
   release:
     types:
       - published
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: Git ref to publish from
+        required: false
+        default: main
 
 jobs:
   publish:
@@ -14,7 +20,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          ref: ${{ github.event.release.tag_name }}
+          ref: ${{ github.event.release.tag_name || inputs.ref || github.ref_name }}
       - uses: actions/setup-node@v6
         with:
           node-version: 24


### PR DESCRIPTION
## Summary
- add workflow_dispatch to the npm publish workflow
- allow a ref input so publish can be retried from the chosen git ref without recreating the release

## Testing
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/publish.yml"); puts "ok"'
- git diff --check -- .github/workflows/publish.yml
