### PR TITLE
Release v1.0.1

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cc",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Claude Code Plugin for Codex. Delegate code reviews, investigations, and tracked tasks to Claude Code from inside Codex.",
   "author": {
     "name": "Sendbird, Inc.",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## v1.0.1
+
+- Install and uninstall through Codex app-server when available, with safe fallback activation on unsupported builds.
+- Remove the global `cc-rescue` agent and keep only managed Codex hooks outside the plugin directory.
+- Switch rescue to the built-in forwarding subagent path and harden hook self-clean behavior.
+- Auto-install missing hooks during `$cc:setup`.
+- Clarify background unread-result nudges and the hooks-only global state model in the README.
+
 ## v1.0.0
 
 - Initial public release of the Claude Code plugin for Codex.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cc-plugin-codex",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cc-plugin-codex",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "Apache-2.0",
       "devDependencies": {
         "@eslint/js": "^10.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cc-plugin-codex",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Claude Code Plugin for Codex by Sendbird",
   "type": "module",
   "author": {

--- a/tests/version-sync.test.mjs
+++ b/tests/version-sync.test.mjs
@@ -30,7 +30,8 @@ function createTempRepo({ packageVersion, pluginVersion }) {
 
 describe("version sync", () => {
   it("asserts the live repo versions match", () => {
-    assert.equal(assertVersionsMatch(), "1.0.0");
+    const { packageVersion } = readVersionPair();
+    assert.equal(assertVersionsMatch(), packageVersion);
   });
 
   it("detects mismatched versions", () => {


### PR DESCRIPTION
## Summary
- bump package and plugin metadata to 1.0.1
- add 1.0.1 changelog entry for the Codex app-server install, hooks-only global state, and rescue/runtime hardening work

## Testing
- npm run check:version-sync
- npm pack --dry-run