### PR TITLE
Release 1.0.5

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cc",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Claude Code Plugin for Codex. Delegate code reviews, investigations, and tracked tasks to Claude Code from inside Codex.",
   "author": {
     "name": "Sendbird, Inc.",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## v1.0.5
+
+- Keep built-in background review jobs attached to the parent Codex session so plain `$cc:status` and `$cc:result` stay intuitive after nested rescue/review flows.
+- Make `$cc:status --all` show the full job history for the current repository workspace instead of staying session-scoped.
+- Harden large-diff review and hook fingerprinting so oversized `git diff` output degrades cleanly instead of failing with `ENOBUFS`.
+- Clarify README guidance around review visibility, large diffs, and the difference between session-scoped status and repository-wide status.
+
 ## v1.0.4
 
 - Make background built-in rescue/review completions steer users to `$cc:result <job-id>` instead of inlining raw child output.

--- a/README.md
+++ b/README.md
@@ -114,6 +114,8 @@ Scope `auto` (the default) inspects `git status` and chooses between working-tre
 
 In foreground, review returns the result directly. In background, the plugin uses a Codex built-in subagent, tracks the review as a job, and nudges you to open the result when it completes.
 
+If the diff is too large to inline safely, the review prompt falls back to concise status/stat context and tells Claude to inspect the diff directly with read-only `git diff` commands instead of failing the run.
+
 ### `$cc:adversarial-review`
 
 Same as `$cc:review`, but steers Claude to challenge the implementation — tradeoffs, alternative approaches, hidden assumptions.
@@ -163,9 +165,11 @@ Background rescue runs through a built-in Codex subagent. When the child finishe
 ```text
 $cc:status                          # list active and recent jobs
 $cc:status task-abc123              # detailed status for one job
-$cc:status --all                    # include older jobs
+$cc:status --all                    # show all tracked jobs in this repository workspace
 $cc:status --wait task-abc123       # block until job completes
 ```
+
+By default, `$cc:status` shows jobs owned by the current Codex session. Use `--all` when you want the wider repository view across older or sibling sessions in the same workspace.
 
 ### `$cc:result`
 
@@ -205,7 +209,7 @@ All review and rescue commands support `--background`. Background jobs are track
 3. **Completion nudges** — when a background built-in flow finishes, the plugin tries to nudge the parent thread with the right `$cc:result <job-id>`. If that nudge cannot surface cleanly, unread-result hooks are the backstop.
    The nudge is intentionally just a pointer. The actual stored result still opens through `$cc:result`.
 4. **Unread-result fallback** — when you submit your next prompt after a finished unread job, Codex can remind you that a result is waiting and point you to `$cc:status` / `$cc:result`.
-5. **Session ownership** — jobs are scoped to the Codex session that created them. Nested sessions do not steal ownership of parent jobs.
+5. **Session ownership** — jobs stay attached to the user-facing parent Codex session even when a built-in rescue/review child does the actual work, so plain `$cc:status` still shows the job you just launched.
 6. **Cleanup on exit** — when your Codex session ends, any still-running detached jobs are terminated via PID identity validation, and stale reserved job markers are cleaned up over time.
 
 **Typical background flow:**
@@ -316,6 +320,18 @@ $cc:status
 $cc:result
 ```
 The built-in notify path is best-effort. The tracked job store and unread hook remain the reliable fallback.
+
+If you think the job may belong to an older session in the same repository, use:
+```text
+$cc:status --all
+```
+
+**Large review diff caused a failure or was omitted**
+That is expected on very large diffs. The plugin now degrades to a compact review context and points Claude toward read-only `git diff` commands instead of trying to inline everything. If you want the full picture, run a narrower review such as:
+```text
+$cc:review --base main
+$cc:review --scope working-tree
+```
 
 **Review gate draining tokens**
 Disable it: `$cc:setup --disable-review-gate`. The gate fires on every Ctrl+C, which adds up.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cc-plugin-codex",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cc-plugin-codex",
-      "version": "1.0.4",
+      "version": "1.0.5",
       "license": "Apache-2.0",
       "devDependencies": {
         "@eslint/js": "^10.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cc-plugin-codex",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Claude Code Plugin for Codex by Sendbird",
   "type": "module",
   "author": {

--- a/scripts/claude-companion.mjs
+++ b/scripts/claude-companion.mjs
@@ -176,6 +176,12 @@ function resolveExplicitJobId(value, workspaceRoot) {
   return explicitJobId;
 }
 
+function resolveOwnerSessionId(value) {
+  const trimmed = value == null ? "" : String(value).trim();
+  if (!trimmed) return null;
+  return sanitizeId(trimmed, "session ID");
+}
+
 async function withReleasedReservation(workspaceRoot, explicitJobId, fn) {
   try {
     return await fn();
@@ -1099,7 +1105,7 @@ async function resolveLatestResumableSession(cwd, options = {}) {
 
 async function handleReviewCommand(argv, config) {
   const { options, positionals } = parseCommandInput(argv, {
-    valueOptions: ["base", "scope", "model", "cwd", "view-state", "job-id"],
+    valueOptions: ["base", "scope", "model", "cwd", "view-state", "job-id", "owner-session-id"],
     booleanOptions: ["json", "background", "wait"],
     aliasMap: {
       m: "model"
@@ -1115,6 +1121,7 @@ async function handleReviewCommand(argv, config) {
     scope: options.scope
   });
   const explicitJobId = resolveExplicitJobId(options["job-id"], workspaceRoot);
+  const ownerSessionId = resolveOwnerSessionId(options["owner-session-id"]);
   const markViewedOnSuccess = resolveMarkViewedOnSuccess(
     options["view-state"],
     Boolean(options.background)
@@ -1132,6 +1139,7 @@ async function handleReviewCommand(argv, config) {
       workspaceRoot,
       jobClass: "review",
       summary: metadata.summary,
+      sessionId: ownerSessionId,
       explicitJobId
     });
 
@@ -1234,7 +1242,7 @@ async function handleTask(argv) {
   ensureClaudeReady(cwd);
 
   const write = Boolean(options.write);
-  const ownerSessionId = options["owner-session-id"] || null;
+  const ownerSessionId = resolveOwnerSessionId(options["owner-session-id"]);
   const explicitJobId = resolveExplicitJobId(options["job-id"], workspaceRoot);
   await withReleasedReservation(workspaceRoot, explicitJobId, async () => {
     const taskMetadata = buildTaskRunMetadata({

--- a/scripts/lib/git.mjs
+++ b/scripts/lib/git.mjs
@@ -7,10 +7,12 @@ import { createHash } from "node:crypto";
 import path from "node:path";
 
 import { isProbablyText } from "./fs.mjs";
-import { runCommand, runCommandChecked } from "./process.mjs";
+import { formatCommandFailure, runCommand, runCommandChecked } from "./process.mjs";
 
 const MAX_UNTRACKED_BYTES = 24 * 1024;
 const MAX_INLINE_REVIEW_DIFF_BYTES = 64 * 1024;
+const REVIEW_DIFF_READ_MAX_BUFFER = MAX_INLINE_REVIEW_DIFF_BYTES + 8 * 1024;
+const HASH_OBJECT_BATCH_SIZE = 128;
 
 function git(cwd, args, options = {}) {
   return runCommand("git", args, { cwd, ...options });
@@ -109,17 +111,16 @@ function buildUntrackedMetadataFingerprint(repoRoot, relativePaths) {
 
 export function getWorkingTreeFingerprint(cwd) {
   const repoRoot = getRepoRoot(cwd);
-  const stagedDiff = gitChecked(repoRoot, [
+  const stagedDiffHash = gitChecked(repoRoot, ["write-tree"]).stdout.trim();
+  const unstaged = gitChecked(repoRoot, [
     "diff",
-    "--cached",
+    "--name-only",
     "--no-ext-diff",
-    "--submodule=diff",
-  ]).stdout;
-  const unstagedDiff = gitChecked(repoRoot, [
-    "diff",
-    "--no-ext-diff",
-    "--submodule=diff",
-  ]).stdout;
+    "-z",
+  ]).stdout
+    .split("\0")
+    .filter(Boolean)
+    .sort();
   const untracked = gitChecked(repoRoot, [
     "ls-files",
     "--others",
@@ -130,8 +131,7 @@ export function getWorkingTreeFingerprint(cwd) {
     .filter(Boolean)
     .sort();
 
-  const stagedDiffHash = hashText(stagedDiff);
-  const unstagedDiffHash = hashText(unstagedDiff);
+  const unstagedDiffHash = hashWorkingTreePaths(repoRoot, unstaged);
   const untrackedFingerprintHash = buildUntrackedMetadataFingerprint(
     repoRoot,
     untracked
@@ -153,6 +153,75 @@ export function getWorkingTreeFingerprint(cwd) {
     untrackedCount: untracked.length,
     signature,
   };
+}
+
+function hashWorkingTreePaths(repoRoot, relativePaths) {
+  const hash = createHash("sha256");
+  const regularPaths = [];
+
+  for (const relativePath of relativePaths) {
+    hash.update(relativePath, "utf8");
+    hash.update("\0", "utf8");
+
+    const absolutePath = path.join(repoRoot, relativePath);
+    try {
+      const stat = fs.lstatSync(absolutePath);
+      if (stat.isDirectory()) {
+        hash.update("directory", "utf8");
+        hash.update("\0", "utf8");
+        hash.update(String(Math.trunc(stat.mtimeMs)), "utf8");
+        hash.update("\0", "utf8");
+        continue;
+      }
+
+      if (stat.isSymbolicLink()) {
+        hash.update("symlink", "utf8");
+        hash.update("\0", "utf8");
+        hash.update(fs.readlinkSync(absolutePath), "utf8");
+        hash.update("\0", "utf8");
+        continue;
+      }
+
+      regularPaths.push(relativePath);
+    } catch (error) {
+      if (error?.code === "ENOENT") {
+        hash.update("deleted", "utf8");
+      } else {
+        throw error;
+      }
+    }
+    hash.update("\0", "utf8");
+  }
+
+  const blobHashes = readBlobHashes(repoRoot, regularPaths);
+  for (const relativePath of regularPaths) {
+    hash.update(blobHashes.get(relativePath), "utf8");
+    hash.update("\0", "utf8");
+  }
+
+  return hash.digest("hex");
+}
+
+function readBlobHashes(repoRoot, relativePaths) {
+  const hashes = new Map();
+  for (let index = 0; index < relativePaths.length; index += HASH_OBJECT_BATCH_SIZE) {
+    const batch = relativePaths.slice(index, index + HASH_OBJECT_BATCH_SIZE);
+    const stdout = gitChecked(repoRoot, ["hash-object", "--no-filters", "--", ...batch]).stdout;
+    const digestLines = stdout
+      .trim()
+      .split("\n")
+      .map((line) => line.trim())
+      .filter(Boolean);
+    if (digestLines.length !== batch.length) {
+      throw new Error(
+        `git hash-object returned ${digestLines.length} hashes for ${batch.length} path(s).`
+      );
+    }
+    batch.forEach((relativePath, batchIndex) => {
+      hashes.set(relativePath, digestLines[batchIndex]);
+    });
+  }
+  return hashes;
 }
 
 export function resolveReviewTarget(cwd, options = {}) {
@@ -259,25 +328,44 @@ function shouldInlineReviewDiff(...sections) {
   return true;
 }
 
+function readBoundedGitDiff(cwd, args) {
+  const result = git(cwd, args, { maxBuffer: REVIEW_DIFF_READ_MAX_BUFFER });
+  if (result.error) {
+    if (result.error.code === "ENOBUFS") {
+      return { text: "", tooLarge: true };
+    }
+    throw new Error(
+      `${result.command} ${result.args.join(" ")}: ${result.error.message}`
+    );
+  }
+  if (result.status !== 0) {
+    throw new Error(formatCommandFailure(result));
+  }
+  return { text: result.stdout, tooLarge: false };
+}
+
 function collectWorkingTreeContext(cwd, state) {
   const status = gitChecked(cwd, ["status", "--short"]).stdout.trim();
-  const stagedDiff = gitChecked(cwd, ["diff", "--cached", "--no-ext-diff", "--submodule=diff"]).stdout;
-  const unstagedDiff = gitChecked(cwd, ["diff", "--no-ext-diff", "--submodule=diff"]).stdout;
   const untrackedBody = state.untracked.map((file) => formatUntrackedFile(cwd, file)).join("\n\n");
-  const inlineDiffs = shouldInlineReviewDiff(status, stagedDiff, unstagedDiff, untrackedBody);
+  const stagedDiff = readBoundedGitDiff(cwd, ["diff", "--cached", "--no-ext-diff", "--submodule=diff"]);
+  const unstagedDiff = readBoundedGitDiff(cwd, ["diff", "--no-ext-diff", "--submodule=diff"]);
+  const inlineDiffs =
+    !stagedDiff.tooLarge &&
+    !unstagedDiff.tooLarge &&
+    shouldInlineReviewDiff(status, stagedDiff.text, unstagedDiff.text, untrackedBody);
 
   const parts = [
     formatSection("Git Status", status),
     formatSection(
       "Staged Diff",
       inlineDiffs
-        ? stagedDiff
+        ? stagedDiff.text
         : "Large diff omitted. Inspect staged changes directly with read-only git commands such as `git diff --cached --no-ext-diff --submodule=diff`."
     ),
     formatSection(
       "Unstaged Diff",
       inlineDiffs
-        ? unstagedDiff
+        ? unstagedDiff.text
         : "Large diff omitted. Inspect unstaged changes directly with read-only git commands such as `git diff --no-ext-diff --submodule=diff`."
     ),
     formatSection("Untracked Files", untrackedBody)
@@ -296,8 +384,10 @@ function collectBranchContext(cwd, baseRef) {
   const currentBranch = getCurrentBranch(cwd);
   const logOutput = gitChecked(cwd, ["log", "--oneline", "--decorate", commitRange]).stdout.trim();
   const diffStat = gitChecked(cwd, ["diff", "--stat", commitRange]).stdout.trim();
-  const diff = gitChecked(cwd, ["diff", "--no-ext-diff", "--submodule=diff", commitRange]).stdout;
-  const inlineDiff = shouldInlineReviewDiff(logOutput, diffStat, diff);
+  const diff = readBoundedGitDiff(cwd, ["diff", "--no-ext-diff", "--submodule=diff", commitRange]);
+  const inlineDiff =
+    !diff.tooLarge &&
+    shouldInlineReviewDiff(logOutput, diffStat, diff.text);
 
   return {
     mode: "branch",
@@ -308,7 +398,7 @@ function collectBranchContext(cwd, baseRef) {
       formatSection(
         "Branch Diff",
         inlineDiff
-          ? diff
+          ? diff.text
           : `Large diff omitted. Inspect the branch diff directly with read-only git commands such as \`git diff --no-ext-diff --submodule=diff ${commitRange}\`.`
       )
     ].join("\n")

--- a/scripts/lib/job-control.mjs
+++ b/scripts/lib/job-control.mjs
@@ -156,10 +156,12 @@ export function buildStatusSnapshot(cwd, options = {}) {
   const workspaceRoot = resolveWorkspaceRoot(cwd);
   const config = getConfig(workspaceRoot);
   const jobs = sortJobsNewestFirst(
-    filterJobsForCurrentSession(listJobs(workspaceRoot), {
-      ...options,
-      cwd: workspaceRoot,
-    })
+    options.all
+      ? listJobs(workspaceRoot)
+      : filterJobsForCurrentSession(listJobs(workspaceRoot), {
+          ...options,
+          cwd: workspaceRoot,
+        })
   );
   const maxJobs = options.maxJobs ?? DEFAULT_MAX_STATUS_JOBS;
   const maxProgressLines = options.maxProgressLines ?? DEFAULT_MAX_PROGRESS_LINES;

--- a/scripts/lib/process.mjs
+++ b/scripts/lib/process.mjs
@@ -13,6 +13,7 @@ export function runCommand(command, args = [], options = {}) {
     env: options.env,
     encoding: "utf8",
     input: options.input,
+    maxBuffer: options.maxBuffer,
     stdio: options.stdio ?? "pipe",
     shell: false
   });

--- a/skills/adversarial-review/SKILL.md
+++ b/skills/adversarial-review/SKILL.md
@@ -58,6 +58,7 @@ Background flow:
 - Before spawning the built-in child, reserve a review job id by running:
   `node "<plugin-root>/scripts/claude-companion.mjs" review-reserve-job --json`
 - If that helper returns a non-empty `jobId`, pass it into the companion command as an internal `--job-id <reserved-job-id>` routing flag.
+- Add an internal `--owner-session-id <parent-session-id>` routing flag when spawning the built-in child so the tracked review job stays visible in the parent Codex session's plain `$cc:status`.
 - If the built-in review is running in background, the parent should first capture its own thread id by running:
   `node -e "process.stdout.write(process.env.CODEX_THREAD_ID || '')"`
 - If that command returns a non-empty thread id, pass it into the child prompt as the parent thread id for one-shot completion notification.
@@ -76,6 +77,7 @@ Background flow:
   - run exactly one shell command
   - execute:
     `node "<plugin-root>/scripts/claude-companion.mjs" adversarial-review --view-state defer <arguments with --wait/--background removed>`
+  - include `--owner-session-id <parent-session-id>` so background review jobs stay attached to the parent session
   - include `--job-id <reserved-job-id>` when the parent reserved one
   - return only that command's stdout exactly, with no added commentary
   - ignore stderr progress chatter such as `[cc] ...` lines and preserve only the final stdout-equivalent result text

--- a/skills/review/SKILL.md
+++ b/skills/review/SKILL.md
@@ -56,6 +56,7 @@ Background flow:
 - Before spawning the built-in child, reserve a review job id by running:
   `node "<plugin-root>/scripts/claude-companion.mjs" review-reserve-job --json`
 - If that helper returns a non-empty `jobId`, pass it into the companion command as an internal `--job-id <reserved-job-id>` routing flag.
+- Add an internal `--owner-session-id <parent-session-id>` routing flag when spawning the built-in child so the tracked review job stays visible in the parent Codex session's plain `$cc:status`.
 - If the built-in review is running in background, the parent should first capture its own thread id by running:
   `node -e "process.stdout.write(process.env.CODEX_THREAD_ID || '')"`
 - If that command returns a non-empty thread id, pass it into the child prompt as the parent thread id for one-shot completion notification.
@@ -74,6 +75,7 @@ Background flow:
   - run exactly one shell command
   - execute:
     `node "<plugin-root>/scripts/claude-companion.mjs" review --view-state defer <arguments with --wait/--background removed>`
+  - include `--owner-session-id <parent-session-id>` so background review jobs stay attached to the parent session
   - include `--job-id <reserved-job-id>` when the parent reserved one
   - return only that command's stdout exactly, with no added commentary
   - ignore stderr progress chatter such as `[cc] ...` lines and preserve only the final stdout-equivalent result text

--- a/skills/status/SKILL.md
+++ b/skills/status/SKILL.md
@@ -15,3 +15,4 @@ Supported arguments: `[job-id]`, `--wait`, `--timeout-ms <ms>`, `--poll-interval
 Output:
 - Present the companion stdout exactly as returned.
 - Do not add extra prose or reformat it.
+- By default, status overview is scoped to the current Codex session in this repository. `--all` widens that overview to all tracked jobs in the current repository workspace.

--- a/tests/git.test.mjs
+++ b/tests/git.test.mjs
@@ -9,7 +9,7 @@ import os from "node:os";
 import path from "node:path";
 import { spawnSync } from "node:child_process";
 
-import { collectReviewContext } from "../scripts/lib/git.mjs";
+import { collectReviewContext, getWorkingTreeFingerprint } from "../scripts/lib/git.mjs";
 
 const tempRepos = [];
 
@@ -147,5 +147,44 @@ describe("collectReviewContext", () => {
     assert.match(context.content, /Large diff omitted\./);
     assert.match(context.content, /git diff --no-ext-diff --submodule=diff/);
     assert.doesNotMatch(context.content, /@@/);
+  });
+
+  it("degrades gracefully when working-tree diff output exceeds the process buffer", () => {
+    const repo = createRepo();
+    const hugeText = `${"z".repeat(2048)}\n`.repeat(700);
+
+    fs.writeFileSync(path.join(repo, "app.js"), "export const value = 1;\n", "utf8");
+    runGit(repo, ["add", "app.js"]);
+    runGit(repo, ["commit", "-m", "initial"]);
+
+    fs.writeFileSync(path.join(repo, "app.js"), hugeText, "utf8");
+
+    const context = collectReviewContext(repo, {
+      mode: "working-tree",
+      label: "working tree diff",
+      explicit: true,
+    });
+
+    assert.match(context.content, /Large diff omitted\./);
+    assert.match(context.content, /git diff --cached --no-ext-diff --submodule=diff/);
+    assert.match(context.content, /git diff --no-ext-diff --submodule=diff/);
+  });
+
+  it("computes a working-tree fingerprint without buffering the full diff text", () => {
+    const repo = createRepo();
+    const hugeText = `${"w".repeat(2048)}\n`.repeat(700);
+
+    fs.writeFileSync(path.join(repo, "app.js"), "export const value = 1;\n", "utf8");
+    runGit(repo, ["add", "app.js"]);
+    runGit(repo, ["commit", "-m", "initial"]);
+
+    fs.writeFileSync(path.join(repo, "app.js"), hugeText, "utf8");
+
+    const fingerprint = getWorkingTreeFingerprint(repo);
+
+    assert.equal(typeof fingerprint.signature, "string");
+    assert.equal(fingerprint.signature.length > 0, true);
+    assert.equal(typeof fingerprint.stagedDiffHash, "string");
+    assert.equal(typeof fingerprint.unstagedDiffHash, "string");
   });
 });

--- a/tests/integration/claude-companion.test.mjs
+++ b/tests/integration/claude-companion.test.mjs
@@ -888,6 +888,75 @@ describe("claude-companion integration", () => {
     }
   });
 
+  it("uses an explicit owner session id so background review jobs stay visible to the parent session", async () => {
+    const testEnv = createTestEnvironment();
+    const childSessionEnv = {
+      ...testEnv.env,
+      [SESSION_ID_ENV]: "child-review-session",
+    };
+
+    try {
+      setupGitWorkspace(testEnv.workspaceDir);
+      seedWorkingTreeDiff(testEnv.workspaceDir);
+      writeCurrentSessionMarker(testEnv, "parent-review-session");
+
+      const launch = await runCompanionAsyncJson(
+        [
+          "review",
+          "--cwd",
+          testEnv.workspaceDir,
+          "--background",
+          "--json",
+          "--scope",
+          "working-tree",
+          "--owner-session-id",
+          "parent-review-session",
+        ],
+        { env: childSessionEnv }
+      );
+      await waitForTerminalStatus(testEnv, launch.jobId, childSessionEnv);
+
+      const storedJob = readStoredJobById(testEnv, launch.jobId);
+      assert.equal(storedJob.sessionId, "parent-review-session");
+
+      const statusPayload = runCompanionJson(
+        ["status", "--cwd", testEnv.workspaceDir, "--json"],
+        { env: testEnv.env }
+      );
+      assert.equal(statusPayload.latestFinished?.id, launch.jobId);
+    } finally {
+      cleanupTestEnvironment(testEnv);
+    }
+  });
+
+  it("rejects invalid owner session ids before creating a background review job", () => {
+    const testEnv = createTestEnvironment();
+
+    try {
+      setupGitWorkspace(testEnv.workspaceDir);
+      seedWorkingTreeDiff(testEnv.workspaceDir);
+
+      const result = runCompanionExpectFailure(
+        [
+          "review",
+          "--cwd",
+          testEnv.workspaceDir,
+          "--background",
+          "--json",
+          "--scope",
+          "working-tree",
+          "--owner-session-id",
+          "invalid session id",
+        ],
+        { env: testEnv.env }
+      );
+
+      assert.match(result.stderr, /Invalid session ID/);
+    } finally {
+      cleanupTestEnvironment(testEnv);
+    }
+  });
+
   it("keeps completed resume candidates session-scoped and ignores active tasks", async () => {
     const testEnv = createTestEnvironment();
     const sessionAEnv = {

--- a/tests/job-control.test.mjs
+++ b/tests/job-control.test.mjs
@@ -124,6 +124,45 @@ describe("buildStatusSnapshot", () => {
       fs.rmSync(repoDir, { recursive: true, force: true });
     }
   });
+
+  it("status --all bypasses the current-session filter and shows workspace jobs", () => {
+    const repoDir = createTempGitRepo();
+    const scopedIds = ["test-status-all-a", "test-status-all-b"];
+    try {
+      writeJobFile(repoDir, scopedIds[0], {
+        id: scopedIds[0],
+        status: "completed",
+        jobClass: "task",
+        sessionId: "session-a",
+        createdAt: "2026-04-03T10:00:00Z",
+        completedAt: "2026-04-03T10:00:01Z",
+        updatedAt: "2026-04-03T10:00:01Z",
+      });
+      writeJobFile(repoDir, scopedIds[1], {
+        id: scopedIds[1],
+        status: "completed",
+        jobClass: "review",
+        sessionId: "session-b",
+        createdAt: "2026-04-03T11:00:00Z",
+        completedAt: "2026-04-03T11:00:01Z",
+        updatedAt: "2026-04-03T11:00:01Z",
+      });
+
+      setCurrentSession(repoDir, "session-a");
+      const snapshot = buildStatusSnapshot(repoDir, { all: true });
+
+      const ids = [
+        snapshot.latestFinished?.id,
+        ...snapshot.recent.map((job) => job.id),
+        ...snapshot.running.map((job) => job.id),
+      ].filter(Boolean);
+      assert.ok(ids.includes(scopedIds[0]));
+      assert.ok(ids.includes(scopedIds[1]));
+    } finally {
+      clearCurrentSession(repoDir);
+      fs.rmSync(repoDir, { recursive: true, force: true });
+    }
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/tests/process.test.mjs
+++ b/tests/process.test.mjs
@@ -77,6 +77,26 @@ describe("runCommand", () => {
     assert.equal(result.status, 0);
     assert.equal(capturedOptions?.shell, false);
   });
+
+  it("passes maxBuffer through to spawnSync", () => {
+    let capturedOptions = null;
+    const result = runCommand("echo", ["hello"], {
+      maxBuffer: 1234,
+      spawnSyncImpl: (_command, _args, options) => {
+        capturedOptions = options;
+        return {
+          status: 0,
+          signal: null,
+          stdout: "hello\n",
+          stderr: "",
+          error: null,
+        };
+      },
+    });
+
+    assert.equal(result.status, 0);
+    assert.equal(capturedOptions?.maxBuffer, 1234);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/tests/skills-contracts.test.mjs
+++ b/tests/skills-contracts.test.mjs
@@ -27,6 +27,7 @@ test("review skills keep background execution outside the companion command", ()
   assert.match(review, /For background review, use Codex's built-in `default` subagent/i);
   assert.match(review, /review-reserve-job --json/i);
   assert.match(review, /internal `--job-id <reserved-job-id>` routing flag/i);
+  assert.match(review, /internal `--owner-session-id <parent-session-id>` routing flag/i);
   assert.match(review, /spawn_agent/i);
   assert.match(review, /`fork_context: false`/i);
   assert.match(review, /`model: "gpt-5\.4-mini"`/i);
@@ -35,6 +36,7 @@ test("review skills keep background execution outside the companion command", ()
   assert.match(review, /Only consider `fork_context: true` as a last resort/i);
   assert.match(review, /retry once with `model: "gpt-5\.4"`/i);
   assert.match(review, /review --view-state defer/i);
+  assert.match(review, /include `--owner-session-id <parent-session-id>` so background review jobs stay attached to the parent session/i);
   assert.match(review, /Background Claude Code review finished\. Open it with \$cc:result <reserved-job-id>\./i);
   assert.match(review, /use these steering messages instead of embedding the raw review result in the notification/i);
   assert.match(review, /do not embed the raw Claude result inside the notification message/i);
@@ -51,6 +53,7 @@ test("review skills keep background execution outside the companion command", ()
   assert.match(adversarial, /For background adversarial review, use Codex's built-in `default` subagent/i);
   assert.match(adversarial, /review-reserve-job --json/i);
   assert.match(adversarial, /internal `--job-id <reserved-job-id>` routing flag/i);
+  assert.match(adversarial, /internal `--owner-session-id <parent-session-id>` routing flag/i);
   assert.match(adversarial, /spawn_agent/i);
   assert.match(adversarial, /`fork_context: false`/i);
   assert.match(adversarial, /`model: "gpt-5\.4-mini"`/i);
@@ -59,6 +62,7 @@ test("review skills keep background execution outside the companion command", ()
   assert.match(adversarial, /Only consider `fork_context: true` as a last resort/i);
   assert.match(adversarial, /retry once with `model: "gpt-5\.4"`/i);
   assert.match(adversarial, /adversarial-review --view-state defer/i);
+  assert.match(adversarial, /include `--owner-session-id <parent-session-id>` so background review jobs stay attached to the parent session/i);
   assert.match(adversarial, /Background Claude Code adversarial review finished\. Open it with \$cc:result <reserved-job-id>\./i);
   assert.match(adversarial, /use these steering messages instead of embedding the raw review result in the notification/i);
   assert.match(adversarial, /do not embed the raw Claude result inside the notification message/i);


### PR DESCRIPTION
## Summary
- harden background review/status ownership so parent-thread jobs stay visible in plain `$cc:status`
- make `$cc:status --all` repository-wide and fix large-diff review/fingerprint handling
- document the 1.0.5 behavior in README and CHANGELOG and bump package/plugin versions

## Verification
- npm run check
- npm pack --dry-run
