### PR TITLE
Release 1.0.6

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cc",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "Claude Code Plugin for Codex. Delegate code reviews, investigations, and tracked tasks to Claude Code from inside Codex.",
   "author": {
     "name": "Sendbird, Inc.",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v1.0.6
+
+- Restore parent-session ownership for built-in background rescue/review runs so resume candidates, plain `$cc:status`, and no-argument `$cc:result` stay aligned after nested child sessions run.
+- Distinguish the owning Codex session from the actual Claude Code session in job rendering so `claude --resume ...` points at the real Claude session instead of the parent owner marker.
+- Tighten the background review and adversarial-review forwarding contracts around `send_input` notification behavior and add E2E coverage for built-in notification steering in both flows.
+
 ## v1.0.5
 
 - Keep built-in background review jobs attached to the parent Codex session so plain `$cc:status` and `$cc:result` stay intuitive after nested rescue/review flows.

--- a/README.md
+++ b/README.md
@@ -178,7 +178,11 @@ $cc:result                          # open the latest finished job for this sess
 $cc:result task-abc123              # show finished job output
 ```
 
-The output includes the Claude session ID. To reopen that session directly:
+When a job came from a built-in background child, the output can show both:
+- the **Claude Code session** you can resume with `claude --resume ...`
+- the **Owning Codex session** that owns the tracked job inside Codex
+
+To reopen the Claude Code session directly:
 
 ```bash
 claude --resume <session-id>
@@ -209,7 +213,7 @@ All review and rescue commands support `--background`. Background jobs are track
 3. **Completion nudges** — when a background built-in flow finishes, the plugin tries to nudge the parent thread with the right `$cc:result <job-id>`. If that nudge cannot surface cleanly, unread-result hooks are the backstop.
    The nudge is intentionally just a pointer. The actual stored result still opens through `$cc:result`.
 4. **Unread-result fallback** — when you submit your next prompt after a finished unread job, Codex can remind you that a result is waiting and point you to `$cc:status` / `$cc:result`.
-5. **Session ownership** — jobs stay attached to the user-facing parent Codex session even when a built-in rescue/review child does the actual work, so plain `$cc:status` still shows the job you just launched.
+5. **Session ownership** — jobs stay attached to the user-facing parent Codex session even when a built-in rescue/review child does the actual work, so plain `$cc:status`, `$cc:result`, and resume-candidate detection still follow the parent thread.
 6. **Cleanup on exit** — when your Codex session ends, any still-running detached jobs are terminated via PID identity validation, and stale reserved job markers are cleaned up over time.
 
 **Typical background flow:**
@@ -325,6 +329,8 @@ If you think the job may belong to an older session in the same repository, use:
 ```text
 $cc:status --all
 ```
+
+If a finished result shows both a **Claude Code session** and an **Owning Codex session**, use the Claude Code session for `claude --resume ...`. The owning session is there only to explain which Codex thread owns the tracked job.
 
 **Large review diff caused a failure or was omitted**
 That is expected on very large diffs. The plugin now degrades to a compact review context and points Claude toward read-only `git diff` commands instead of trying to inline everything. If you want the full picture, run a narrower review such as:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cc-plugin-codex",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cc-plugin-codex",
-      "version": "1.0.5",
+      "version": "1.0.6",
       "license": "Apache-2.0",
       "devDependencies": {
         "@eslint/js": "^10.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cc-plugin-codex",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "Claude Code Plugin for Codex by Sendbird",
   "type": "module",
   "author": {

--- a/scripts/claude-companion.mjs
+++ b/scripts/claude-companion.mjs
@@ -61,6 +61,7 @@ import {
   resolveJobsDir,
   resolveJobLogFile,
   sanitizeId,
+  setCurrentSession,
   setConfig,
   transitionJob,
   writeJobFile,
@@ -180,6 +181,13 @@ function resolveOwnerSessionId(value) {
   const trimmed = value == null ? "" : String(value).trim();
   if (!trimmed) return null;
   return sanitizeId(trimmed, "session ID");
+}
+
+function alignCurrentSessionToOwner(workspaceRoot, ownerSessionId) {
+  if (!ownerSessionId) {
+    return;
+  }
+  setCurrentSession(workspaceRoot, ownerSessionId);
 }
 
 async function withReleasedReservation(workspaceRoot, explicitJobId, fn) {
@@ -1131,6 +1139,7 @@ async function handleReviewCommand(argv, config) {
     // Validate inside the reservation guard so failures do not leak markers.
     config.validateRequest?.(target, focusText);
     const metadata = buildReviewJobMetadata(config.reviewName, target);
+    alignCurrentSessionToOwner(workspaceRoot, ownerSessionId);
 
     const job = createCompanionJob({
       prefix: "review",
@@ -1249,6 +1258,7 @@ async function handleTask(argv) {
       prompt,
       resumeLast
     });
+    alignCurrentSessionToOwner(workspaceRoot, ownerSessionId);
 
     // Resolve resume session inside the reservation guard so failures do not leak markers.
     let resumeSessionId = null;

--- a/scripts/lib/render.mjs
+++ b/scripts/lib/render.mjs
@@ -108,9 +108,23 @@ export function escapeMarkdownCell(value) {
   return String(value ?? "").replace(/\|/g, "\\|").replace(/\r?\n/g, " ").trim();
 }
 
-function formatClaudeResumeCommand(job) {
-  if (!job?.sessionId) return null;
-  return `claude --resume ${job.sessionId}`;
+function resolveClaudeSessionId(job, storedJob = null) {
+  return (
+    storedJob?.result?.sessionId ??
+    storedJob?.threadId ??
+    job?.threadId ??
+    null
+  );
+}
+
+function resolveOwningSessionId(job, storedJob = null) {
+  return storedJob?.sessionId ?? job?.sessionId ?? null;
+}
+
+function formatClaudeResumeCommand(job, storedJob = null) {
+  const sessionId = resolveClaudeSessionId(job, storedJob);
+  if (!sessionId) return null;
+  return `claude --resume ${sessionId}`;
 }
 
 function formatClaudeSkillCommand(skill, jobId = null) {
@@ -306,7 +320,14 @@ export function renderJobStatusReport(job) {
   pushKeyValueTableRow(lines, "Ended", job.completedAt ?? "");
   if (isPendingJob(job)) pushKeyValueTableRow(lines, "Elapsed", job.elapsed ?? "");
   else pushKeyValueTableRow(lines, "Duration", job.duration ?? job.elapsed ?? "");
-  if (job.sessionId) pushKeyValueTableRow(lines, "Claude Code session", `\`${job.sessionId}\``, { raw: true });
+  const ownerSessionId = resolveOwningSessionId(job);
+  const claudeSessionId = resolveClaudeSessionId(job);
+  if (claudeSessionId) {
+    pushKeyValueTableRow(lines, "Claude Code session", `\`${claudeSessionId}\``, { raw: true });
+  }
+  if (ownerSessionId && ownerSessionId !== claudeSessionId) {
+    pushKeyValueTableRow(lines, "Owning Codex session", `\`${ownerSessionId}\``, { raw: true });
+  }
   const resumeCmd = formatClaudeResumeCommand(job);
   if (resumeCmd) pushKeyValueTableRow(lines, "Resume", `\`${resumeCmd}\``, { raw: true });
   const logLink = formatLogFileLink(job.logFile);
@@ -328,23 +349,34 @@ export function renderJobStatusReport(job) {
 }
 
 export function renderStoredJobResult(job, storedJob) {
-  const sessionId = storedJob?.sessionId ?? job.sessionId ?? null;
-  const resumeCmd = sessionId ? `claude --resume ${sessionId}` : null;
+  const ownerSessionId = resolveOwningSessionId(job, storedJob);
+  const claudeSessionId = resolveClaudeSessionId(job, storedJob);
+  const resumeCmd = formatClaudeResumeCommand(job, storedJob);
   const recoveredStructuredOutput = normalizeStoredOutput(
     recoverStructuredStoredReviewOutput(job, storedJob)
   );
   if (recoveredStructuredOutput) {
-    if (!sessionId) return recoveredStructuredOutput;
-    return `${recoveredStructuredOutput}\nClaude Code session: ${sessionId}\nResume: ${resumeCmd}\n`;
+    if (!claudeSessionId && !ownerSessionId) return recoveredStructuredOutput;
+    let suffix = "";
+    if (claudeSessionId) suffix += `\nClaude Code session: ${claudeSessionId}\n`;
+    if (ownerSessionId && ownerSessionId !== claudeSessionId) suffix += `Owning Codex session: ${ownerSessionId}\n`;
+    if (resumeCmd) suffix += `Resume: ${resumeCmd}\n`;
+    return `${recoveredStructuredOutput}${suffix}`;
   }
   const storedOutput = normalizeStoredOutput(getStoredJobOutput(storedJob));
   if (storedOutput) {
     const output = storedOutput;
-    if (!sessionId) return output;
-    return `${output}\nClaude Code session: ${sessionId}\nResume: ${resumeCmd}\n`;
+    if (!claudeSessionId && !ownerSessionId) return output;
+    let suffix = "\n";
+    if (claudeSessionId) suffix += `Claude Code session: ${claudeSessionId}\n`;
+    if (ownerSessionId && ownerSessionId !== claudeSessionId) suffix += `Owning Codex session: ${ownerSessionId}\n`;
+    if (resumeCmd) suffix += `Resume: ${resumeCmd}\n`;
+    return `${output}${suffix}`;
   }
   const lines = [`# ${job.title ?? "Claude Code Result"}`, "", `Job: ${job.id}`, `Status: ${job.status}`];
-  if (sessionId) { lines.push(`Claude Code session: ${sessionId}`); lines.push(`Resume: ${resumeCmd}`); }
+  if (claudeSessionId) lines.push(`Claude Code session: ${claudeSessionId}`);
+  if (ownerSessionId && ownerSessionId !== claudeSessionId) lines.push(`Owning Codex session: ${ownerSessionId}`);
+  if (resumeCmd) lines.push(`Resume: ${resumeCmd}`);
   if (job.summary) lines.push(`Summary: ${job.summary}`);
   if (job.errorMessage) lines.push("", job.errorMessage);
   else if (storedJob?.errorMessage) lines.push("", storedJob.errorMessage);

--- a/skills/adversarial-review/SKILL.md
+++ b/skills/adversarial-review/SKILL.md
@@ -82,11 +82,14 @@ Background flow:
   - return only that command's stdout exactly, with no added commentary
   - ignore stderr progress chatter such as `[cc] ...` lines and preserve only the final stdout-equivalent result text
   - not inspect the repo or perform the review itself
-  - if a parent thread id is available, allow one extra `send_input` after success and before finishing
+  - if a parent thread id is available, allow one extra `send_input` call after a successful shell result and before finishing
+  - that `send_input` call must target the provided parent thread id, must happen at most once, and must not run on failure paths
+  - if the parent provided a non-empty parent thread id, do not silently drop the completion notification path from the child prompt
   - if a reserved review job id is available, use this exact notification message:
     `Background Claude Code adversarial review finished. Open it with $cc:result <reserved-job-id>.`
   - otherwise fall back to:
     `Background Claude Code adversarial review finished. Inspect it with $cc:status first, then use $cc:result for the finished job you want to open.`
+  - that `send_input` message should use one of those exact steering messages instead of inlining the raw review result
   - use these steering messages instead of embedding the raw review result in the notification
   - do not embed the raw Claude result inside the notification message
   - do not include any other prose in that notification message

--- a/skills/review/SKILL.md
+++ b/skills/review/SKILL.md
@@ -80,11 +80,14 @@ Background flow:
   - return only that command's stdout exactly, with no added commentary
   - ignore stderr progress chatter such as `[cc] ...` lines and preserve only the final stdout-equivalent result text
   - not inspect the repo or perform the review itself
-  - if a parent thread id is available, allow one extra `send_input` after success and before finishing
+  - if a parent thread id is available, allow one extra `send_input` call after a successful shell result and before finishing
+  - that `send_input` call must target the provided parent thread id, must happen at most once, and must not run on failure paths
+  - if the parent provided a non-empty parent thread id, do not silently drop the completion notification path from the child prompt
   - if a reserved review job id is available, use this exact notification message:
     `Background Claude Code review finished. Open it with $cc:result <reserved-job-id>.`
   - otherwise fall back to:
     `Background Claude Code review finished. Inspect it with $cc:status first, then use $cc:result for the finished job you want to open.`
+  - that `send_input` message should use one of those exact steering messages instead of inlining the raw review result
   - use these steering messages instead of embedding the raw review result in the notification
   - do not embed the raw Claude result inside the notification message
   - do not include any other prose in that notification message

--- a/tests/e2e/codex-skills-e2e.test.mjs
+++ b/tests/e2e/codex-skills-e2e.test.mjs
@@ -695,10 +695,14 @@ function startMockProvider({
   taskPrompt,
   userRequest,
   mode = "builtin-default",
+  skillTitle = "Claude Code Rescue",
+  expectedParentNeedles = [],
   taskCommand: taskCommandOverride = null,
   expectedChildNeedles = [],
   expectedFinalOutput = null,
   notificationMessage = null,
+  spawnMessage = null,
+  childPromptChecks = "rescue",
 }) {
   const requests = [];
   const errors = [];
@@ -751,13 +755,19 @@ function startMockProvider({
           phases.push("parent-init");
           const serializedUserRequest = JSON.stringify(userRequest).slice(1, -1);
           assert.ok(
-            bodyText.includes("Claude Code Rescue"),
-            "rescue skill should be injected into the parent turn"
+            bodyText.includes(skillTitle),
+            `${skillTitle} skill should be injected into the parent turn`
           );
           assert.ok(
             bodyText.includes(userRequest) || bodyText.includes(serializedUserRequest),
             "raw user prompt should reach the parent turn"
           );
+          for (const needle of expectedParentNeedles) {
+            assert.ok(
+              bodyText.includes(needle),
+              `parent turn should include ${needle}`
+            );
+          }
           assert.ok(
             getToolNames(body).includes("spawn_agent"),
             "spawn_agent should be available in the parent turn"
@@ -788,6 +798,7 @@ function startMockProvider({
             model: "gpt-5.4-mini",
             reasoning_effort: "medium",
             message:
+              spawnMessage ??
               "You are a transient forwarding worker for Claude Code rescue.\n" +
               "Run exactly one shell command.\n" +
               "Return only that command's stdout text exactly.\n" +
@@ -810,42 +821,44 @@ function startMockProvider({
         } else if (responseIndex === 2) {
           phases.push("child-shell");
           assert.ok(
-            bodyText.includes("Run exactly one shell command") ||
-              bodyText.includes("Run exactly this command and return stdout unchanged"),
-            "spawned child turn should receive the forwarding contract"
-          );
-          assert.ok(
             bodyText.includes(COMPANION_SCRIPT),
             "spawned child turn should receive the companion path"
           );
-          assert.ok(
-            bodyText.includes("transient forwarding worker for Claude Code rescue"),
-            "built-in child should receive the stricter forwarding contract"
-          );
-          assert.ok(
-            bodyText.includes("Return only that command's stdout text exactly"),
-            "built-in child should be told to preserve stdout exactly"
-          );
-          assert.ok(
-            bodyText.includes("Ignore stderr progress chatter such as [cc] lines."),
-            "built-in child should be told to ignore stderr progress chatter"
-          );
-          assert.ok(
-            bodyText.includes("preserve only the final stdout-equivalent result text"),
-            "built-in child should be told to prefer the final stdout-equivalent result over stderr chatter"
-          );
-          assert.ok(
-            bodyText.includes("Do not drop prefixes like completed:"),
-            "built-in child should be told not to strip completed: prefixes"
-          );
-          assert.ok(
-            bodyText.includes("Do not trim, normalize, add punctuation, or add commentary."),
-            "built-in child should be told not to rewrite stdout"
-          );
-          assert.ok(
-            bodyText.includes("Copy the resolved rescue task text byte-for-byte"),
-            "built-in child should be told to preserve the exact task text in the command"
-          );
+          if (childPromptChecks === "rescue") {
+            assert.ok(
+              bodyText.includes("Run exactly one shell command") ||
+                bodyText.includes("Run exactly this command and return stdout unchanged"),
+              "spawned child turn should receive the forwarding contract"
+            );
+            assert.ok(
+              bodyText.includes("transient forwarding worker for Claude Code rescue"),
+              "built-in child should receive the stricter forwarding contract"
+            );
+            assert.ok(
+              bodyText.includes("Return only that command's stdout text exactly"),
+              "built-in child should be told to preserve stdout exactly"
+            );
+            assert.ok(
+              bodyText.includes("Ignore stderr progress chatter such as [cc] lines."),
+              "built-in child should be told to ignore stderr progress chatter"
+            );
+            assert.ok(
+              bodyText.includes("preserve only the final stdout-equivalent result text"),
+              "built-in child should be told to prefer the final stdout-equivalent result over stderr chatter"
+            );
+            assert.ok(
+              bodyText.includes("Do not drop prefixes like completed:"),
+              "built-in child should be told not to strip completed: prefixes"
+            );
+            assert.ok(
+              bodyText.includes("Do not trim, normalize, add punctuation, or add commentary."),
+              "built-in child should be told not to rewrite stdout"
+            );
+            assert.ok(
+              bodyText.includes("Copy the resolved rescue task text byte-for-byte"),
+              "built-in child should be told to preserve the exact task text in the command"
+            );
+          }
           assert.doesNotMatch(
             bodyText,
             /claude-companion\.mjs"\s+task\s+--background|claude-companion\.mjs"\s+task\s+--wait|claude-companion\.mjs\s+task\s+--background|claude-companion\.mjs\s+task\s+--wait/,
@@ -1676,6 +1689,93 @@ describe("Codex direct-skill E2E", () => {
     }
   });
 
+  it("routes $cc:review --background through the built-in path with notification steering", async (t) => {
+    if (!codexAvailable()) {
+      t.skip("codex CLI is not available in this environment");
+      return;
+    }
+
+    const testEnv = createEnvironment();
+    const workspaceDir = path.join(testEnv.rootDir, "review-background-workspace");
+    fs.mkdirSync(workspaceDir, { recursive: true });
+    setupGitWorkspace(workspaceDir);
+    fs.writeFileSync(
+      path.join(workspaceDir, "app.js"),
+      "export function value() {\n  return 5;\n}\n",
+      "utf8"
+    );
+
+    const reservedJobId = "review-background-steer-123";
+    const ownerSessionId = "parent-review-session";
+    const userRequest = "$cc:review --background --scope working-tree --model haiku";
+    const notificationMessage =
+      `Background Claude Code review finished. Open it with $cc:result ${reservedJobId}.`;
+    const provider = startMockProvider({
+      taskPrompt: "background review raw output should not surface",
+      userRequest,
+      skillTitle: "Claude Code Review",
+      expectedParentNeedles: [
+        "review-reserve-job --json",
+        "--owner-session-id <parent-session-id>",
+        "allow one extra `send_input` call after a successful shell result",
+        "must target the provided parent thread id",
+        "do not silently drop the completion notification path from the child prompt",
+        "Background Claude Code review finished. Open it with $cc:result <reserved-job-id>.",
+      ],
+      taskCommand:
+        `node ${JSON.stringify(COMPANION_SCRIPT)} review --view-state defer --scope working-tree --model haiku --job-id ${JSON.stringify(reservedJobId)} --owner-session-id ${JSON.stringify(ownerSessionId)}`,
+      expectedChildNeedles: [
+        "--view-state defer",
+        "--job-id",
+        reservedJobId,
+        "--owner-session-id",
+        ownerSessionId,
+        "send_input",
+        notificationMessage,
+      ],
+      notificationMessage,
+      childPromptChecks: "generic",
+      spawnMessage:
+        "You are a pure forwarder for a background Claude Code review job.\n" +
+        "Do not inspect the repo, do not review anything yourself, and do not add commentary.\n" +
+        "Run exactly one shell command and capture only the stdout-equivalent final result text from that command, ignoring stderr progress chatter like [cc] lines.\n" +
+        "If the command succeeds and a parent thread id is available, send exactly this notification to the parent thread before finishing: " +
+        JSON.stringify(notificationMessage) + "\n" +
+        "Use that same sentence as your own final assistant message.\n" +
+        "If the command fails, return only the command stdout if any, otherwise a terse failure note.\n\n" +
+        `node ${JSON.stringify(COMPANION_SCRIPT)} review --view-state defer --scope working-tree --model haiku --job-id ${JSON.stringify(reservedJobId)} --owner-session-id ${JSON.stringify(ownerSessionId)}`,
+    });
+    testEnv.providerPort = await provider.listen();
+    installHooks(testEnv);
+    writeConfigToml(testEnv, testEnv.providerPort);
+
+    try {
+      const execResult = await runCodexExec(
+        testEnv,
+        buildSkillPrompt("cc:review", REVIEW_SKILL_PATH, userRequest),
+        { cwd: workspaceDir }
+      );
+
+      assert.equal(
+        execResult.status,
+        0,
+        [
+          "background review codex exec failed",
+          `stdout:\n${execResult.stdout}`,
+          `stderr:\n${execResult.stderr}`,
+          `provider requests: ${provider.requests.length}`,
+          `provider errors: ${JSON.stringify(provider.errors, null, 2)}`,
+        ].join("\n\n")
+      );
+
+      const finalMessage = fs.readFileSync(testEnv.outputFile, "utf8").trim();
+      assert.equal(finalMessage, notificationMessage);
+    } finally {
+      await provider.close();
+      cleanupEnvironment(testEnv);
+    }
+  });
+
   it("routes $cc:adversarial-review --wait through the companion command with focus text", async (t) => {
     if (!codexAvailable()) {
       t.skip("codex CLI is not available in this environment");
@@ -1725,6 +1825,99 @@ describe("Codex direct-skill E2E", () => {
         claudeInvocations.some((entry) => entry.prompt.includes("focus on race conditions")),
         "adversarial review e2e should preserve the user focus text in the Claude prompt"
       );
+    } finally {
+      await provider.close();
+      cleanupEnvironment(testEnv);
+    }
+  });
+
+  it("routes $cc:adversarial-review --background through the built-in path with notification steering", async (t) => {
+    if (!codexAvailable()) {
+      t.skip("codex CLI is not available in this environment");
+      return;
+    }
+
+    const testEnv = createEnvironment();
+    const workspaceDir = path.join(testEnv.rootDir, "adversarial-background-workspace");
+    fs.mkdirSync(workspaceDir, { recursive: true });
+    setupGitWorkspace(workspaceDir);
+    fs.writeFileSync(
+      path.join(workspaceDir, "app.js"),
+      "export function value() {\n  return 6;\n}\n",
+      "utf8"
+    );
+
+    const reservedJobId = "adversarial-background-steer-123";
+    const ownerSessionId = "parent-adversarial-session";
+    const userRequest =
+      "$cc:adversarial-review --background --scope working-tree --model haiku focus on race conditions";
+    const notificationMessage =
+      `Background Claude Code adversarial review finished. Open it with $cc:result ${reservedJobId}.`;
+    const provider = startMockProvider({
+      taskPrompt: "background adversarial review raw output should not surface",
+      userRequest,
+      skillTitle: "Claude Code Adversarial Review",
+      expectedParentNeedles: [
+        "review-reserve-job --json",
+        "--owner-session-id <parent-session-id>",
+        "allow one extra `send_input` call after a successful shell result",
+        "must target the provided parent thread id",
+        "do not silently drop the completion notification path from the child prompt",
+        "Background Claude Code adversarial review finished. Open it with $cc:result <reserved-job-id>.",
+      ],
+      taskCommand:
+        `node ${JSON.stringify(COMPANION_SCRIPT)} adversarial-review --view-state defer --scope working-tree --model haiku --job-id ${JSON.stringify(reservedJobId)} --owner-session-id ${JSON.stringify(ownerSessionId)} focus on race conditions`,
+      expectedChildNeedles: [
+        "--view-state defer",
+        "--job-id",
+        reservedJobId,
+        "--owner-session-id",
+        ownerSessionId,
+        "send_input",
+        notificationMessage,
+        "focus on race conditions",
+      ],
+      notificationMessage,
+      childPromptChecks: "generic",
+      spawnMessage:
+        "You are a pure forwarder for a background Claude Code adversarial review job.\n" +
+        "Do not inspect the repo, do not review anything yourself, and do not add commentary.\n" +
+        "Run exactly one shell command and capture only the stdout-equivalent final result text from that command, ignoring stderr progress chatter like [cc] lines.\n" +
+        "If the command succeeds and a parent thread id is available, send exactly this notification to the parent thread before finishing: " +
+        JSON.stringify(notificationMessage) + "\n" +
+        "Use that same sentence as your own final assistant message.\n" +
+        "If the command fails, return only the command stdout if any, otherwise a terse failure note.\n\n" +
+        `node ${JSON.stringify(COMPANION_SCRIPT)} adversarial-review --view-state defer --scope working-tree --model haiku --job-id ${JSON.stringify(reservedJobId)} --owner-session-id ${JSON.stringify(ownerSessionId)} focus on race conditions`,
+    });
+    testEnv.providerPort = await provider.listen();
+    installHooks(testEnv);
+    writeConfigToml(testEnv, testEnv.providerPort);
+
+    try {
+      const execResult = await runCodexExec(
+        testEnv,
+        buildSkillPrompt(
+          "cc:adversarial-review",
+          ADVERSARIAL_REVIEW_SKILL_PATH,
+          userRequest
+        ),
+        { cwd: workspaceDir }
+      );
+
+      assert.equal(
+        execResult.status,
+        0,
+        [
+          "background adversarial review codex exec failed",
+          `stdout:\n${execResult.stdout}`,
+          `stderr:\n${execResult.stderr}`,
+          `provider requests: ${provider.requests.length}`,
+          `provider errors: ${JSON.stringify(provider.errors, null, 2)}`,
+        ].join("\n\n")
+      );
+
+      const finalMessage = fs.readFileSync(testEnv.outputFile, "utf8").trim();
+      assert.equal(finalMessage, notificationMessage);
     } finally {
       await provider.close();
       cleanupEnvironment(testEnv);

--- a/tests/integration/claude-companion.test.mjs
+++ b/tests/integration/claude-companion.test.mjs
@@ -877,12 +877,26 @@ describe("claude-companion integration", () => {
 
       const storedJob = readStoredJobById(testEnv, launch.jobId);
       assert.equal(storedJob.sessionId, "parent-session");
+      assert.equal(
+        JSON.parse(
+          fs.readFileSync(path.join(stateDirFor(testEnv), "current-session.json"), "utf8")
+        ).sessionId,
+        "parent-session"
+      );
 
       const statusPayload = runCompanionJson(
         ["status", "--cwd", testEnv.workspaceDir, "--json"],
         { env: testEnv.env }
       );
       assert.equal(statusPayload.latestFinished?.id, launch.jobId);
+
+      const resumeCandidate = runCompanionJson(
+        ["task-resume-candidate", "--cwd", testEnv.workspaceDir, "--json"],
+        { env: testEnv.env }
+      );
+      assert.equal(resumeCandidate.available, true);
+      assert.equal(resumeCandidate.sessionId, "parent-session");
+      assert.equal(resumeCandidate.candidate?.id, launch.jobId);
     } finally {
       cleanupTestEnvironment(testEnv);
     }
@@ -918,6 +932,12 @@ describe("claude-companion integration", () => {
 
       const storedJob = readStoredJobById(testEnv, launch.jobId);
       assert.equal(storedJob.sessionId, "parent-review-session");
+      assert.equal(
+        JSON.parse(
+          fs.readFileSync(path.join(stateDirFor(testEnv), "current-session.json"), "utf8")
+        ).sessionId,
+        "parent-review-session"
+      );
 
       const statusPayload = runCompanionJson(
         ["status", "--cwd", testEnv.workspaceDir, "--json"],

--- a/tests/render.test.mjs
+++ b/tests/render.test.mjs
@@ -456,7 +456,8 @@ describe("renderJobStatusReport", () => {
       startedAt: "2026-04-02T19:00:00.000Z",
       completedAt: "2026-04-02T19:01:00.000Z",
       duration: "1m",
-      sessionId: "sess1",
+      sessionId: "owner-sess",
+      threadId: "claude-sess",
       logFile: "/tmp/log.txt",
     };
     const output = renderJobStatusReport(job);
@@ -470,7 +471,9 @@ describe("renderJobStatusReport", () => {
     assert.ok(output.includes("| Duration | 1m |"));
     assert.ok(output.includes("| Log | [log.txt](/tmp/log.txt) |"));
     assert.ok(output.includes("| Result | `$cc:result j1` |"));
-    assert.ok(output.includes("| Resume | `claude --resume sess1` |"));
+    assert.ok(output.includes("| Claude Code session | `claude-sess` |"));
+    assert.ok(output.includes("| Owning Codex session | `owner-sess` |"));
+    assert.ok(output.includes("| Resume | `claude --resume claude-sess` |"));
   });
 
   it("shows cancel action for active jobs", () => {
@@ -495,15 +498,29 @@ describe("renderJobStatusReport", () => {
 
 describe("renderStoredJobResult", () => {
   it("returns rendered content with session info", () => {
-    const job = { id: "j1", sessionId: "sess1" };
+    const job = { id: "j1", sessionId: "owner-sess", threadId: "claude-sess" };
     const stored = {
-      sessionId: "sess1",
-      result: { result: {} },
+      sessionId: "owner-sess",
+      result: { result: {}, sessionId: "claude-sess" },
       rendered: "Review output here.",
     };
     const output = renderStoredJobResult(job, stored);
     assert.ok(output.includes("Review output here."));
-    assert.ok(output.includes("claude --resume sess1"));
+    assert.ok(output.includes("Claude Code session: claude-sess"));
+    assert.ok(output.includes("Owning Codex session: owner-sess"));
+    assert.ok(output.includes("claude --resume claude-sess"));
+  });
+
+  it("does not treat the owning Codex session as a Claude resume target", () => {
+    const job = { id: "j1", sessionId: "owner-sess" };
+    const stored = {
+      sessionId: "owner-sess",
+      rendered: "Review output here.",
+    };
+    const output = renderStoredJobResult(job, stored);
+    assert.ok(output.includes("Owning Codex session: owner-sess"));
+    assert.ok(!output.includes("Claude Code session: owner-sess"));
+    assert.ok(!output.includes("claude --resume owner-sess"));
   });
 
   it("returns rendered content for plain standard reviews", () => {

--- a/tests/skills-contracts.test.mjs
+++ b/tests/skills-contracts.test.mjs
@@ -37,7 +37,11 @@ test("review skills keep background execution outside the companion command", ()
   assert.match(review, /retry once with `model: "gpt-5\.4"`/i);
   assert.match(review, /review --view-state defer/i);
   assert.match(review, /include `--owner-session-id <parent-session-id>` so background review jobs stay attached to the parent session/i);
+  assert.match(review, /allow one extra `send_input` call after a successful shell result/i);
+  assert.match(review, /must target the provided parent thread id/i);
+  assert.match(review, /do not silently drop the completion notification path from the child prompt/i);
   assert.match(review, /Background Claude Code review finished\. Open it with \$cc:result <reserved-job-id>\./i);
+  assert.match(review, /that `send_input` message should use one of those exact steering messages/i);
   assert.match(review, /use these steering messages instead of embedding the raw review result in the notification/i);
   assert.match(review, /do not embed the raw Claude result inside the notification message/i);
   assert.match(review, /do not include any other prose in that notification message/i);
@@ -63,7 +67,11 @@ test("review skills keep background execution outside the companion command", ()
   assert.match(adversarial, /retry once with `model: "gpt-5\.4"`/i);
   assert.match(adversarial, /adversarial-review --view-state defer/i);
   assert.match(adversarial, /include `--owner-session-id <parent-session-id>` so background review jobs stay attached to the parent session/i);
+  assert.match(adversarial, /allow one extra `send_input` call after a successful shell result/i);
+  assert.match(adversarial, /must target the provided parent thread id/i);
+  assert.match(adversarial, /do not silently drop the completion notification path from the child prompt/i);
   assert.match(adversarial, /Background Claude Code adversarial review finished\. Open it with \$cc:result <reserved-job-id>\./i);
+  assert.match(adversarial, /that `send_input` message should use one of those exact steering messages/i);
   assert.match(adversarial, /use these steering messages instead of embedding the raw review result in the notification/i);
   assert.match(adversarial, /do not embed the raw Claude result inside the notification message/i);
   assert.match(adversarial, /do not include any other prose in that notification message/i);


### PR DESCRIPTION
## Summary
- restore parent-session ownership for built-in background review/rescue flows so status and resume-candidate stay aligned
- separate owning Codex session vs Claude Code session in rendered job/result output and resume guidance
- tighten background review/adversarial-review notification contracts and add E2E coverage for built-in notification steering

## Verification
- npm run check
- npm pack --dry-run
