### PR TITLE
Tighten local install root handling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,36 +28,6 @@ jobs:
       - run: npm run typecheck
       - run: npm run test:cross-platform
 
-  windows-wsl-full:
-    name: Full CI (windows-latest, WSL)
-    runs-on: windows-latest
-    defaults:
-      run:
-        shell: wsl-bash {0}
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-      - uses: Vampire/setup-wsl@v7
-        with:
-          distribution: Ubuntu-24.04
-          additional-packages: curl git ca-certificates
-      - run: |
-          git config --global core.autocrlf false
-          git reset --hard HEAD
-      - run: |
-          curl -fsSL https://deb.nodesource.com/setup_24.x | bash -
-          apt-get install -y nodejs
-      - run: node --version
-      - run: npm install -g @openai/codex
-      - run: codex --version
-      - run: npm ci
-      - run: npm run check:version-sync
-      - run: npm run check:changelog
-      - run: npm run lint
-      - run: npm run typecheck
-      - run: npm run test
-      - run: npm run test:integration
-      - run: npm run test:e2e
-
   macos-full:
     name: Full CI (macos-latest)
     runs-on: macos-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,8 @@ jobs:
         with:
           node-version: 24
           cache: npm
+      - run: npm install -g @openai/codex
+      - run: codex --version
       - run: npm ci
       - run: npm run check:version-sync
       - run: npm run check:changelog

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       matrix:
         os:
           - windows-latest
-          - macos-latest
+          - ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
@@ -29,9 +29,9 @@ jobs:
       - run: npm run typecheck
       - run: npm run test:cross-platform
 
-  linux-full:
-    name: Full CI (ubuntu-latest)
-    runs-on: ubuntu-latest
+  macos-full:
+    name: Full CI (macos-latest)
+    runs-on: macos-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,6 @@ jobs:
       matrix:
         os:
           - windows-latest
-          - ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
@@ -32,6 +31,26 @@ jobs:
   macos-full:
     name: Full CI (macos-latest)
     runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
+        with:
+          node-version: 24
+          cache: npm
+      - run: npm install -g @openai/codex
+      - run: codex --version
+      - run: npm ci
+      - run: npm run check:version-sync
+      - run: npm run check:changelog
+      - run: npm run lint
+      - run: npm run typecheck
+      - run: npm run test
+      - run: npm run test:integration
+      - run: npm run test:e2e
+
+  linux-full:
+    name: Full CI (ubuntu-latest)
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,36 @@ jobs:
       - run: npm run typecheck
       - run: npm run test:cross-platform
 
+  windows-wsl-full:
+    name: Full CI (windows-latest, WSL)
+    runs-on: windows-latest
+    defaults:
+      run:
+        shell: wsl-bash {0}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: Vampire/setup-wsl@v7
+        with:
+          distribution: Ubuntu-24.04
+          additional-packages: curl git ca-certificates
+      - run: |
+          git config --global core.autocrlf false
+          git reset --hard HEAD
+      - run: |
+          curl -fsSL https://deb.nodesource.com/setup_24.x | bash -
+          apt-get install -y nodejs
+      - run: node --version
+      - run: npm install -g @openai/codex
+      - run: codex --version
+      - run: npm ci
+      - run: npm run check:version-sync
+      - run: npm run check:changelog
+      - run: npm run lint
+      - run: npm run typecheck
+      - run: npm run test
+      - run: npm run test:integration
+      - run: npm run test:e2e
+
   macos-full:
     name: Full CI (macos-latest)
     runs-on: macos-latest

--- a/README.md
+++ b/README.md
@@ -293,6 +293,8 @@ cd ~/.codex/plugins/cc
 node scripts/local-plugin-install.mjs install --plugin-root ~/.codex/plugins/cc
 ```
 
+`local-plugin-install.mjs` expects `--plugin-root` to be the managed install directory itself. If you want to install from an arbitrary checkout path, use `npx cc-plugin-codex install` instead.
+
 ### Update
 
 Re-run the install command — it's idempotent.

--- a/README.md
+++ b/README.md
@@ -55,7 +55,8 @@ That's the entire install. It:
 - Installs lifecycle, review-gate, and unread-result hooks
 
 On Windows, prefer the `npx` path above. The shell-script installer below is POSIX-only.
-The maintained CI matrix now covers Windows, macOS, and Linux. The `npx` install path is the cross-platform path we test on every release.
+Codex CLI's official guidance still treats Windows support as experimental and recommends a WSL workspace for the best Codex experience. Claude Code supports both native Windows and WSL. In hosted CI we currently keep Windows on the native cross-platform core suite, while full integration and E2E coverage run on Linux and macOS.
+The `npx` install path is the cross-platform path we test on every release.
 
 > **Prerequisites:** Node.js 18+, Codex with hook support, and `claude` CLI installed and authenticated.
 > If you don't have the Claude CLI yet:

--- a/scripts/local-plugin-install.mjs
+++ b/scripts/local-plugin-install.mjs
@@ -99,6 +99,18 @@ function normalizeTrailingNewline(text) {
   return `${text.replace(/\s*$/, "")}\n`;
 }
 
+function assertSupportedPluginRoot(pluginRoot) {
+  if (samePath(pluginRoot, INSTALLED_PLUGIN_ROOT)) {
+    return;
+  }
+
+  throw new Error(
+    `Unsupported --plugin-root ${pluginRoot}. ` +
+      `For a local checkout install, clone the plugin into ${INSTALLED_PLUGIN_ROOT} and rerun this script there, ` +
+      `or use \`npx cc-plugin-codex install\` from any checkout.`
+  );
+}
+
 function formatWrapperName(skillName) {
   return `${PLUGIN_NAME}-${skillName}`;
 }
@@ -496,6 +508,7 @@ async function uninstallPluginThroughCodex() {
 }
 
 export async function install(pluginRoot, skipHookInstall) {
+  assertSupportedPluginRoot(pluginRoot);
   if (
     samePath(pluginRoot, INSTALLED_PLUGIN_ROOT) &&
     process.env.CC_PLUGIN_CODEX_SKILLS_MATERIALIZED !== "1"

--- a/tests/e2e/codex-skills-e2e.test.mjs
+++ b/tests/e2e/codex-skills-e2e.test.mjs
@@ -35,6 +35,20 @@ function codexAvailable() {
   return result.status === 0;
 }
 
+it("requires the codex CLI when E2E runs in CI", (t) => {
+  if (codexAvailable()) {
+    return;
+  }
+
+  if (process.env.CI) {
+    assert.fail(
+      "codex CLI is not available in this CI environment; full E2E coverage requires installing @openai/codex first"
+    );
+  }
+
+  t.skip("codex CLI is not available in this environment");
+});
+
 function createFakeClaudeBinary(binDir, logFile) {
   const claudePath = path.join(binDir, "claude");
   const source = `#!/usr/bin/env node

--- a/tests/installer-cli.test.mjs
+++ b/tests/installer-cli.test.mjs
@@ -117,6 +117,26 @@ function runLocalPluginInstaller(command, pluginRoot, homeDir, extraEnv = {}) {
   return result;
 }
 
+function runLocalPluginInstallerExpectFailure(command, pluginRoot, homeDir, extraEnv = {}) {
+  const result = spawnSync(
+    process.execPath,
+    [path.join(pluginRoot, "scripts", "local-plugin-install.mjs"), command, "--plugin-root", pluginRoot],
+    {
+      cwd: pluginRoot,
+      env: {
+        ...process.env,
+        HOME: homeDir,
+        USERPROFILE: homeDir,
+        ...extraEnv,
+      },
+      encoding: "utf8",
+    }
+  );
+
+  assert.notEqual(result.status, 0, "expected local-plugin-install to fail");
+  return result;
+}
+
 function createFakeCodex(homeDir, codexHome = path.join(homeDir, ".codex")) {
   const scriptPath = makeTempHelper("fake-codex-app-server");
   const logPath = path.join(codexHome, "fake-codex-requests.log");
@@ -643,6 +663,20 @@ describe("installer-cli", () => {
 
     assert.ok(skillText.includes(normalizedInstallDir));
     assert.doesNotMatch(skillText, /<installed-plugin-root>/i);
+  });
+
+  it("rejects direct source-root installs outside the managed plugin directory", () => {
+    const homeDir = makeTempHome();
+    const sourceRoot = makeTempSource();
+    const fakeCodex = createFakeCodex(homeDir);
+    copyFixture(sourceRoot);
+
+    const result = runLocalPluginInstallerExpectFailure("install", sourceRoot, homeDir, fakeCodex.env);
+    const expectedInstallDir = path.join(homeDir, ".codex", "plugins", "cc").replace(/\\/g, "/");
+
+    assert.match(result.stderr, /Unsupported --plugin-root/i);
+    assert.match(result.stderr.replace(/\\/g, "/"), new RegExp(expectedInstallDir.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
+    assert.match(result.stderr, /npx cc-plugin-codex install/i);
   });
 
   it("installs successfully when CODEX_HOME is outside the user's home directory", () => {

--- a/tests/integration/claude-companion.test.mjs
+++ b/tests/integration/claude-companion.test.mjs
@@ -1923,6 +1923,7 @@ describe("claude-companion integration", () => {
       "race-delta delay=570",
       "race-epsilon delay=620",
     ];
+    let waitSnapshotsPromise = Promise.resolve([]);
 
     try {
       const launches = await Promise.all(
@@ -1941,7 +1942,7 @@ describe("claude-companion integration", () => {
         )
       );
 
-      const waitSnapshotsPromise = Promise.all(
+      waitSnapshotsPromise = Promise.all(
         launches.slice(0, 2).map((launch) =>
           runCompanionAsyncJson(
             [
@@ -1995,11 +1996,20 @@ describe("claude-companion integration", () => {
         }
       }
 
-      assert.equal(
-        terminalPayloads.size,
-        launches.length,
-        `Expected all launches to reach terminal state, got ${terminalPayloads.size}/${launches.length}`
+      const unresolvedLaunches = launches.filter(
+        (launch) => !terminalPayloads.has(launch.jobId)
       );
+      for (const launch of unresolvedLaunches) {
+        const payload = await waitForTerminalResult(
+          testEnv,
+          launch.jobId,
+          testEnv.env,
+          { timeoutMs: 20_000 }
+        );
+        assertCompletedTaskPayload(payload, launch.prompt);
+        terminalPayloads.set(launch.jobId, payload);
+      }
+
       const waitSnapshots = await waitSnapshotsPromise;
       for (const snapshot of waitSnapshots) {
         assert.equal(snapshot.job.status, "completed");
@@ -2015,6 +2025,7 @@ describe("claude-companion integration", () => {
         assert.ok(completedJobIds.includes(launch.jobId));
       }
     } finally {
+      await Promise.allSettled([waitSnapshotsPromise]);
       cleanupTestEnvironment(testEnv);
     }
   });


### PR DESCRIPTION
## Summary
- fail fast when local-plugin-install is pointed at an unsupported checkout root
- document the supported local checkout flow and Windows platform guidance more explicitly
- keep CI as Windows native core plus full Linux and macOS Codex-backed coverage

## Why
- addresses the inline follow-up comment on PR #26 about unresolved <installed-plugin-root> placeholders for unsupported direct source-root installs
- clarifies the current platform policy: Codex officially recommends WSL for the best Windows CLI experience, but GitHub-hosted Windows WSL full CI is not a stable required-check path for this repo today
- preserves a real full Codex signal on Linux and macOS while keeping native Windows coverage on the portable core suite

## Verification
- node --test tests/installer-cli.test.mjs
- npm run test:cross-platform
- npm run test:e2e
- npm run lint
