### PR TITLE
Clarify review versus rescue skill routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,11 @@ When it finishes, Codex should nudge you toward the right result. If not, `$cc:s
 | `$cc:cancel` | Cancel an active background job |
 | `$cc:setup` | Verify installation, auth, hooks, and review gate |
 
+Quick routing rule:
+- Use `$cc:review` for straightforward correctness review of the current diff.
+- Use `$cc:adversarial-review` for riskier config/template/migration/design changes, or whenever you want stronger challenge on assumptions and tradeoffs.
+- Use `$cc:rescue` when you want Claude Code to investigate, validate by changing code, or actually fix/implement something.
+
 ### `$cc:review`
 
 Standard read-only review of your current work.

--- a/skills/adversarial-review/SKILL.md
+++ b/skills/adversarial-review/SKILL.md
@@ -1,11 +1,15 @@
 ---
 name: adversarial-review
-description: 'Run a design-challenging Claude Code review of local git changes in this repository. Args: --wait, --background, --base <ref>, --scope <auto|working-tree|branch>, --model <model>, [focus text]. Use when the user wants stronger scrutiny, tradeoff analysis, or custom review focus text.'
+description: 'Run a design-challenging Claude Code review of local git changes in this repository. Args: --wait, --background, --base <ref>, --scope <auto|working-tree|branch>, --model <model>, [focus text]. Use when the user wants stronger scrutiny, tradeoff analysis, risky-change review, or custom review focus text.'
 ---
 
 # Claude Code Adversarial Review
 
 Use this skill when the user wants Claude Code to challenge the implementation approach, design choices, assumptions, or tradeoffs in this repository.
+
+Prefer `$cc:adversarial-review` over `$cc:review` when the change touches configuration, infrastructure, templating, rollout mechanics, migrations, safety controls, or "this should remove mismatch/drift" style refactors.
+Use it even without extra focus text when the real question is "did this actually eliminate the risk or just move it around?"
+If the user wants Claude Code to go beyond review and perform investigation, validation edits, or implementation work, route to `$cc:rescue` instead.
 
 Do not derive the companion path from this skill file or any cache directory. Always run the installed copy:
 `node "<installed-plugin-root>/scripts/claude-companion.mjs" adversarial-review ...`

--- a/skills/rescue/SKILL.md
+++ b/skills/rescue/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: rescue
-description: 'Delegate a substantial diagnosis, implementation, or follow-up task to Claude Code through the tracked-job runtime. Args: --background, --wait, --resume, --resume-last, --fresh, --write, --model <model>, --effort <low|medium|high|max>, --prompt-file <path>, [task text]. Use for deeper work, not for standard review or quick local questions.'
+description: 'Delegate a substantial diagnosis, implementation, or follow-up task to Claude Code through the tracked-job runtime. Args: --background, --wait, --resume, --resume-last, --fresh, --write, --model <model>, --effort <low|medium|high|max>, --prompt-file <path>, [task text]. Use when Claude should investigate or change things, not when the user only wants review findings.'
 ---
 
 # Claude Code Rescue
@@ -11,6 +11,9 @@ Spawn exactly one rescue forwarding subagent whose only job is to run one compan
 Foreground rescue responses must be that subagent's output verbatim.
 
 Use this skill when the user wants Claude Code to investigate, implement, or continue substantial work in this repository.
+
+Prefer `$cc:rescue` when the user wants Claude Code to diagnose the issue, validate a risky change by actually editing or testing, apply fixes from a prior review, or carry a task forward across multiple steps.
+Do not use rescue for "just review this diff" unless the user also wants follow-through work beyond review findings.
 
 Do not derive the companion path from this skill file or any cache directory. Always run the installed copy:
 `node "<installed-plugin-root>/scripts/claude-companion.mjs" task ...`

--- a/skills/review/SKILL.md
+++ b/skills/review/SKILL.md
@@ -1,11 +1,15 @@
 ---
 name: review
-description: 'Run a standard Claude Code review of local git changes in this repository. Args: --wait, --background, --base <ref>, --scope <auto|working-tree|branch>, --model <model>. Use for normal diff review requests, not staged-only review or custom focus text.'
+description: 'Run a standard Claude Code review of local git changes in this repository. Args: --wait, --background, --base <ref>, --scope <auto|working-tree|branch>, --model <model>. Use for straightforward correctness-oriented diff review when the user wants findings only, not custom focus text, adversarial framing, or implementation work.'
 ---
 
 # Claude Code Review
 
 Use this skill when the user wants Claude Code to review the current working tree or a branch diff in this repository.
+
+Choose `$cc:review` only for straightforward review requests where the user mainly wants correctness findings on the current diff.
+If the user wants stronger challenge on design, rollout risk, migration risk, configuration behavior, template mismatch elimination, or any custom focus text, route to `$cc:adversarial-review` instead.
+If the user wants Claude Code to investigate, validate by changing code, or actually fix/implement something, route to `$cc:rescue` instead.
 
 Do not derive the companion path from this skill file or any cache directory. Always run the installed copy:
 `node "<installed-plugin-root>/scripts/claude-companion.mjs" review ...`

--- a/tests/skills-contracts.test.mjs
+++ b/tests/skills-contracts.test.mjs
@@ -22,6 +22,9 @@ test("review skills keep background execution outside the companion command", ()
   const installedRootPattern = /<installed-plugin-root>\/scripts\/claude-companion\.mjs/i;
 
   assert.match(review, /Do not derive the companion path from this skill file or any cache directory/i);
+  assert.match(review, /Choose `\$cc:review` only for straightforward review requests where the user mainly wants correctness findings on the current diff/i);
+  assert.match(review, /If the user wants stronger challenge on design, rollout risk, migration risk, configuration behavior, template mismatch elimination, or any custom focus text, route to `\$cc:adversarial-review` instead/i);
+  assert.match(review, /If the user wants Claude Code to investigate, validate by changing code, or actually fix\/implement something, route to `\$cc:rescue` instead/i);
   assert.match(review, installedRootPattern);
   assert.match(review, /Treat `--wait` and `--background` as Codex-side execution controls only/i);
   assert.match(review, /Strip them before calling the companion command/i);
@@ -60,6 +63,9 @@ test("review skills keep background execution outside the companion command", ()
   assert.doesNotMatch(review, /claude-companion\.mjs" review \$ARGUMENTS/i);
 
   assert.match(adversarial, /Do not derive the companion path from this skill file or any cache directory/i);
+  assert.match(adversarial, /Prefer `\$cc:adversarial-review` over `\$cc:review` when the change touches configuration, infrastructure, templating, rollout mechanics, migrations, safety controls, or "this should remove mismatch\/drift" style refactors/i);
+  assert.match(adversarial, /Use it even without extra focus text when the real question is "did this actually eliminate the risk or just move it around\?"/i);
+  assert.match(adversarial, /If the user wants Claude Code to go beyond review and perform investigation, validation edits, or implementation work, route to `\$cc:rescue` instead/i);
   assert.match(adversarial, installedRootPattern);
   assert.match(adversarial, /Treat `--wait` and `--background` as Codex-side execution controls only/i);
   assert.match(adversarial, /Strip them before calling the companion command/i);
@@ -103,6 +109,8 @@ test("rescue skill keeps --background and --wait as host-side controls only", ()
   const installedRootPattern = /<installed-plugin-root>\/scripts\/claude-companion\.mjs/i;
 
   assert.match(rescue, /Do not derive the companion path from this skill file or any cache directory/i);
+  assert.match(rescue, /Prefer `\$cc:rescue` when the user wants Claude Code to diagnose the issue, validate a risky change by actually editing or testing, apply fixes from a prior review, or carry a task forward across multiple steps/i);
+  assert.match(rescue, /Do not use rescue for "just review this diff" unless the user also wants follow-through work beyond review findings/i);
   assert.match(rescue, installedRootPattern);
   assert.match(rescue, /`--background` and `--wait` are Codex-side execution controls only/i);
   assert.match(rescue, /Never satisfy background rescue by launching `claude-companion\.mjs task` itself as a detached shell process/i);


### PR DESCRIPTION
## Summary
- make the review/adversarial-review/rescue boundaries explicit in the skill contracts
- add a short routing rule to the README
- lock the wording in skills contract tests

## Why
- config/template/migration style changes were too easy to route into plain review even when adversarial review was the better fit
- users should not have to restate the intended skill boundary by hand

## Verification
- node --test tests/skills-contracts.test.mjs
- npm run lint
- git diff --check
