### PR TITLE
Install Codex in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,6 +26,8 @@ jobs:
           node-version: 24
           cache: npm
           registry-url: "https://registry.npmjs.org"
+      - run: npm install -g @openai/codex
+      - run: codex --version
       - run: npm ci
       - run: npm run check:version-sync
       - run: npm run check:changelog


### PR DESCRIPTION
## Summary
- install @openai/codex in the npm publish workflow
- verify the Codex binary before running the full release check

## Why
- the 1.0.8 release workflow failed because publish.yml ran npm run check without Codex installed, so the E2E CI guard failed on ubuntu

## Verification
- npm run lint
- git diff --check
