### PR TITLE
fix: run stop gate through git MCP

### DIFF
--- a/hooks/stop-review-gate-hook.mjs
+++ b/hooks/stop-review-gate-hook.mjs
@@ -36,7 +36,9 @@ import {
 import {
   getClaudeAvailability,
   getClaudeAuthStatus,
+  cleanupReviewMcpConfig,
   cleanupSandboxSettings,
+  createReviewMcpConfig,
   createSandboxSettings,
   runClaudeReview,
   SANDBOX_STOP_REVIEW_TOOLS,
@@ -167,14 +169,18 @@ function parseStopReviewOutput(rawOutput) {
 async function runStopReview(cwd, input = {}) {
   const prompt = buildStopReviewPrompt(input);
   const sandboxSettingsFile = createSandboxSettings("read-only");
+  let mcpConfigFile = null;
   const promptBytes = Buffer.byteLength(prompt, "utf8");
 
   try {
+    mcpConfigFile = createReviewMcpConfig(resolveWorkspaceRoot(cwd));
     const result = await runClaudeReview(cwd, prompt, {
       allowedTools: SANDBOX_STOP_REVIEW_TOOLS,
       maxTurns: 5,
       permissionMode: "dontAsk",
       settingsFile: sandboxSettingsFile,
+      mcpConfigFile,
+      strictMcpConfig: true,
     });
 
     if (result.status !== "completed") {
@@ -221,6 +227,7 @@ async function runStopReview(cwd, input = {}) {
       reason: `The stop-time Claude Code review failed: ${detail}`
     };
   } finally {
+    cleanupReviewMcpConfig(mcpConfigFile);
     cleanupSandboxSettings(sandboxSettingsFile);
   }
 }

--- a/scripts/lib/claude-cli.mjs
+++ b/scripts/lib/claude-cli.mjs
@@ -345,15 +345,6 @@ export const SANDBOX_READ_ONLY_BASH_TOOLS = [
   "Bash(git config --get:*)",
 ];
 
-export const SANDBOX_STOP_REVIEW_TOOLS = [
-  "Read",
-  "Glob",
-  "Grep",
-  "Bash(git log:*)",
-  "Bash(git diff:*)",
-  "Bash(git show:*)",
-];
-
 /** read-only: file reading + read-only git + web + read-only agents. No writes, MCP, or skills. */
 export const SANDBOX_READ_ONLY_TOOLS = [
   "Read",
@@ -384,6 +375,13 @@ export const REVIEW_MCP_TOOL_NAMES = [
 export const REVIEW_MCP_ALLOWED_TOOLS = REVIEW_MCP_TOOL_NAMES.map(
   (name) => `mcp__${REVIEW_MCP_SERVER_NAME}__${name}`
 );
+
+export const SANDBOX_STOP_REVIEW_TOOLS = [
+  "Read",
+  "Glob",
+  "Grep",
+  ...REVIEW_MCP_ALLOWED_TOOLS,
+];
 
 /**
  * Tools exposed to review/adversarial-review runs. Bash is intentionally absent —

--- a/tests/hooks.test.mjs
+++ b/tests/hooks.test.mjs
@@ -317,16 +317,11 @@ describe("hooks", () => {
           allowedTools.push(claudeArgs[i + 1]);
         }
       }
-      assert.deepEqual(allowedTools, SANDBOX_STOP_REVIEW_TOOLS);
-      for (const allowedTool of allowedTools) {
-        assert.ok(
-          !/^Bash(\(|$)/.test(allowedTool),
-          `stop review allowlist must not contain Bash: ${allowedTool}`
-        );
-      }
-      for (const expectedTool of REVIEW_MCP_ALLOWED_TOOLS) {
-        assert.ok(allowedTools.includes(expectedTool), `missing ${expectedTool}`);
-      }
+      assert.deepEqual(
+        allowedTools,
+        ["Read", "Glob", "Grep", ...REVIEW_MCP_ALLOWED_TOOLS],
+        "stop review must expose only read tools and the bundled read-only git MCP"
+      );
 
       const mcpConfigIndex = claudeArgs.indexOf("--mcp-config");
       const mcpConfigPath = claudeArgs[mcpConfigIndex + 1];

--- a/tests/hooks.test.mjs
+++ b/tests/hooks.test.mjs
@@ -11,7 +11,11 @@ import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
-import { SANDBOX_STOP_REVIEW_TOOLS } from "../scripts/lib/claude-cli.mjs";
+import {
+  REVIEW_MCP_ALLOWED_TOOLS,
+  REVIEW_MCP_SERVER_NAME,
+  SANDBOX_STOP_REVIEW_TOOLS,
+} from "../scripts/lib/claude-cli.mjs";
 import { SESSION_ID_ENV } from "../scripts/lib/tracked-jobs.mjs";
 
 const PROJECT_ROOT = path.resolve(
@@ -42,6 +46,12 @@ const args = process.argv.slice(2);
 
 if (process.env.CLAUDE_ARGS_FILE) {
   fs.writeFileSync(process.env.CLAUDE_ARGS_FILE, JSON.stringify(args, null, 2) + "\\n", "utf8");
+}
+if (process.env.CLAUDE_MCP_CONFIG_FILE) {
+  const mcpConfigIndex = args.indexOf("--mcp-config");
+  if (mcpConfigIndex >= 0 && args[mcpConfigIndex + 1]) {
+    fs.copyFileSync(args[mcpConfigIndex + 1], process.env.CLAUDE_MCP_CONFIG_FILE);
+  }
 }
 
   if (args[0] === "-p") {
@@ -258,7 +268,7 @@ function writeTurnBaselineSnapshot(testEnv, sessionId, fingerprint) {
 }
 
 describe("hooks", () => {
-  it("stop-review hook uses read-only sandbox settings when review gate is enabled", () => {
+  it("stop-review hook uses read-only sandbox and git MCP when review gate is enabled", () => {
     const testEnv = createHookEnvironment();
 
     try {
@@ -271,6 +281,7 @@ describe("hooks", () => {
       );
 
       const argsFile = path.join(testEnv.rootDir, "claude-args.json");
+      const mcpConfigCaptureFile = path.join(testEnv.rootDir, "claude-mcp-config.json");
       const result = runHook(
         STOP_HOOK,
         [],
@@ -281,6 +292,7 @@ describe("hooks", () => {
         {
           ...testEnv.env,
           CLAUDE_ARGS_FILE: argsFile,
+          CLAUDE_MCP_CONFIG_FILE: mcpConfigCaptureFile,
         }
       );
 
@@ -296,6 +308,8 @@ describe("hooks", () => {
       assert.ok(permissionModeIndex >= 0);
       assert.equal(claudeArgs[permissionModeIndex + 1], "dontAsk");
       assert.ok(claudeArgs.includes("--settings"));
+      assert.ok(claudeArgs.includes("--mcp-config"));
+      assert.ok(claudeArgs.includes("--strict-mcp-config"));
 
       const allowedTools = [];
       for (let i = 0; i < claudeArgs.length; i++) {
@@ -304,6 +318,26 @@ describe("hooks", () => {
         }
       }
       assert.deepEqual(allowedTools, SANDBOX_STOP_REVIEW_TOOLS);
+      for (const allowedTool of allowedTools) {
+        assert.ok(
+          !/^Bash(\(|$)/.test(allowedTool),
+          `stop review allowlist must not contain Bash: ${allowedTool}`
+        );
+      }
+      for (const expectedTool of REVIEW_MCP_ALLOWED_TOOLS) {
+        assert.ok(allowedTools.includes(expectedTool), `missing ${expectedTool}`);
+      }
+
+      const mcpConfigIndex = claudeArgs.indexOf("--mcp-config");
+      const mcpConfigPath = claudeArgs[mcpConfigIndex + 1];
+      assert.equal(fs.existsSync(mcpConfigPath), false);
+      const capturedMcpConfig = JSON.parse(fs.readFileSync(mcpConfigCaptureFile, "utf8"));
+      const server = capturedMcpConfig.mcpServers[REVIEW_MCP_SERVER_NAME];
+      assert.ok(server);
+      assert.equal(
+        fs.realpathSync.native(server.env.CC_GIT_ROOT),
+        fs.realpathSync.native(testEnv.workspaceDir)
+      );
     } finally {
       cleanupHookEnvironment(testEnv);
     }

--- a/tests/sandbox-modes.test.mjs
+++ b/tests/sandbox-modes.test.mjs
@@ -13,6 +13,7 @@ import {
   SANDBOX_READ_ONLY_BASH_TOOLS,
   SANDBOX_READ_ONLY_TOOLS,
   SANDBOX_REVIEW_TOOLS,
+  SANDBOX_STOP_REVIEW_TOOLS,
   SANDBOX_TEMP_DIR,
   SANDBOX_SETTINGS,
   REVIEW_MCP_SERVER_NAME,
@@ -308,6 +309,26 @@ describe("SANDBOX_REVIEW_TOOLS", () => {
   it("REVIEW_MCP_TOOL_NAMES covers diff, log, show, blame, status, grep, ls_files", () => {
     for (const expected of ["diff", "log", "show", "blame", "status", "grep", "ls_files"]) {
       assert.ok(REVIEW_MCP_TOOL_NAMES.includes(expected), `missing ${expected}`);
+    }
+  });
+});
+
+describe("SANDBOX_STOP_REVIEW_TOOLS", () => {
+  it("uses read tools plus bundled git MCP tools without Bash", () => {
+    for (const t of ["Read", "Glob", "Grep"]) {
+      assert.ok(SANDBOX_STOP_REVIEW_TOOLS.includes(t), `missing ${t}`);
+    }
+    for (const t of SANDBOX_STOP_REVIEW_TOOLS) {
+      assert.ok(
+        !/^Bash(\(|$)/.test(t),
+        `stop review allowlist must not contain Bash: ${t}`
+      );
+    }
+    for (const expected of REVIEW_MCP_ALLOWED_TOOLS) {
+      assert.ok(
+        SANDBOX_STOP_REVIEW_TOOLS.includes(expected),
+        `missing MCP tool entry: ${expected}`
+      );
     }
   });
 });

--- a/tests/sandbox-modes.test.mjs
+++ b/tests/sandbox-modes.test.mjs
@@ -314,22 +314,13 @@ describe("SANDBOX_REVIEW_TOOLS", () => {
 });
 
 describe("SANDBOX_STOP_REVIEW_TOOLS", () => {
-  it("uses read tools plus bundled git MCP tools without Bash", () => {
-    for (const t of ["Read", "Glob", "Grep"]) {
-      assert.ok(SANDBOX_STOP_REVIEW_TOOLS.includes(t), `missing ${t}`);
-    }
-    for (const t of SANDBOX_STOP_REVIEW_TOOLS) {
-      assert.ok(
-        !/^Bash(\(|$)/.test(t),
-        `stop review allowlist must not contain Bash: ${t}`
-      );
-    }
-    for (const expected of REVIEW_MCP_ALLOWED_TOOLS) {
-      assert.ok(
-        SANDBOX_STOP_REVIEW_TOOLS.includes(expected),
-        `missing MCP tool entry: ${expected}`
-      );
-    }
+  it("uses exactly the read tools plus bundled git MCP tools", () => {
+    assert.deepEqual(SANDBOX_STOP_REVIEW_TOOLS, [
+      "Read",
+      "Glob",
+      "Grep",
+      ...REVIEW_MCP_ALLOWED_TOOLS,
+    ]);
   });
 });
 


### PR DESCRIPTION
## Summary

- Route the stop review gate through the bundled read-only git MCP server.
- Remove Bash from the stop-time review allowlist.
- Keep the current stop-gate policy unchanged: Claude review failures still block; setup-not-ready still skips.

## Root Cause

The standard review path already avoids Bash because Claude CLI does not strictly enforce `Bash(<pattern>:*)` subpatterns. The stop review gate still used `Bash(git ...)` entries, which exposed a broader shell surface and diverged from the safer review/adversarial-review path.

## Changes

- `SANDBOX_STOP_REVIEW_TOOLS` now contains only `Read`, `Glob`, `Grep`, and the read-only git MCP tool entries.
- `stop-review-gate-hook.mjs` now creates a git MCP config, passes `--mcp-config` with `--strict-mcp-config`, and cleans it up after the review.
- Tests now assert the stop gate has no Bash tools, includes the MCP tools, passes strict MCP config, and cleans up the transient MCP config.

Related to #52.

## Validation

- `npm run lint`
- `npm run typecheck`
- `npm run check:version-sync`
- `npm run check:changelog`
- `npm test` (478/478)
- `npm run test:integration` (39/39)
- `git diff --check`
