### PR TITLE
fix: use Claude-compatible review schema dialect

### DIFF
--- a/schemas/review-output.schema.json
+++ b/schemas/review-output.schema.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
   "additionalProperties": false,
   "required": [

--- a/tests/review-schema.test.mjs
+++ b/tests/review-schema.test.mjs
@@ -1,0 +1,34 @@
+/**
+ * Copyright 2026 Sendbird, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const PROJECT_ROOT = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  ".."
+);
+const POST_DRAFT_07_KEYWORD = /"(?:\$anchor|\$defs|\$dynamicAnchor|\$dynamicRef|\$recursiveAnchor|\$recursiveRef|contentSchema|dependentRequired|dependentSchemas|maxContains|minContains|prefixItems|unevaluatedItems|unevaluatedProperties)"\s*:/;
+const schemaSource = fs.readFileSync(
+  path.join(PROJECT_ROOT, "schemas", "review-output.schema.json"),
+  "utf8"
+);
+const schema = JSON.parse(schemaSource);
+
+describe("adversarial review output schema", () => {
+  it("declares the Draft-07 dialect accepted by Claude Code", () => {
+    assert.equal(
+      schema.$schema,
+      "http://json-schema.org/draft-07/schema#",
+      "Claude Code 2.1.205+ rejects the Draft 2020-12 declaration before review execution; see #72"
+    );
+  });
+
+  it("does not use schema keywords introduced after Draft-07", () => {
+    assert.doesNotMatch(schemaSource, POST_DRAFT_07_KEYWORD);
+  });
+});


### PR DESCRIPTION
## Summary

- switch the adversarial-review output schema from Draft 2020-12 to the Draft-07 URI accepted by current Claude Code
- add regression coverage for the required dialect and guard against post–Draft-07 keywords

Fixes #72.

## Root cause

Claude Code 2.1.205 changed invalid `--json-schema` handling from silently returning unstructured output to failing before model execution. The plugin's bundled schema declares Draft 2020-12, which Claude Code 2.1.211 rejects with:

```text
Error: --json-schema is not a valid JSON Schema: no schema with key or ref "https://json-schema.org/draft/2020-12/schema"
```

The companion passes the bundled schema verbatim to `--json-schema`, so `$cc:adversarial-review` cannot start.

## Why this URI

The accepted identifier is specifically:

```text
http://json-schema.org/draft-07/schema#
```

Empirical checks against Claude Code 2.1.211 showed:

- Draft 2020-12 declaration: rejected before execution
- HTTPS spelling of Draft-07: rejected before execution
- canonical HTTP Draft-07 URI: accepted and returned structured output
- the complete patched companion schema: accepted end to end; adversarial review reached Claude and returned structured review output

The bundled schema uses only Draft-07-compatible keywords. The new regression test also rejects known schema keywords introduced after Draft-07 so future edits cannot silently invalidate the compatibility contract.

## Validation

- RED regression: `node --test tests/review-schema.test.mjs` — 0 passed / 1 failed on the Draft 2020-12 URI
- GREEN regression: 2/2 passed
- `npm run lint` — passed
- `npm run typecheck` — passed
- `npm run check:version-sync` — passed
- `npm run check:changelog` — passed
- `npm test` — 479/479 passed
- `npm run test:integration` — 36/36 passed
- focused foreground adversarial-review E2E — 1/1 passed
- real patched companion adversarial-review using Claude Code 2.1.211 — reached Claude and produced structured output

The unfiltered Codex E2E run produced 8 passes and 14 failures in rescue/background-routing cases because the Codex 0.144.5 mock-provider harness reported `spawn_agent should be available in the parent turn`. The foreground `$cc:adversarial-review --wait` E2E affected by this change passed; none of the 14 failures exercises the schema file.
