### PR TITLE
refactor: delegate model resolution to Claude Code

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,9 @@ $cc:review --model opus --effort high   # opus with a lighter effort
 
 **Flags:** `--base <ref>`, `--scope <auto|working-tree|branch>`, `--wait`, `--background`, `--model <model>`, `--effort <low|medium|high|xhigh|max>`
 
-**Defaults:** model `opus` (resolves to `claude-opus-4-7[1m]`, the 1M-context variant) with `xhigh` effort. If you pick `sonnet`, it resolves to `claude-sonnet-4-6[1m]` (also 1M context) and the default effort drops to `high`. `fable` passes through to Claude Code and also defaults to `high`. `haiku` resolves to `claude-haiku-4-5` and has no effort setting. Pass `--model` and `--effort` to override.
+**Defaults:** model `opus` with `xhigh` effort. Friendly aliases such as `fable`, `opus`, `sonnet`, and `haiku` pass directly to Claude Code, which resolves them for your account and provider. `sonnet` and `fable` default to `high`; `haiku` has no effort setting. Full model IDs and provider-specific names also pass through unchanged and receive no inferred effort. Pass `--model` and `--effort` to override.
+
+**Model discovery:** run `/model` in Claude Code to see the models and effort levels available to your current account and provider, then pass the selected alias or full ID to this plugin. The plugin intentionally does not maintain a static model catalog or force `[1m]`; Claude Code owns alias versions, managed restrictions, provider routing, and extended-context eligibility.
 
 Scope `auto` (the default) inspects `git status` and chooses between working-tree and branch automatically.
 
@@ -172,7 +174,7 @@ $cc:rescue --model sonnet --effort medium investigate the flaky test
 | `--resume-last` | Alias for `--resume` |
 | `--fresh` | Force a new task (don't resume) |
 | `--write` | Allow file edits (default) |
-| `--model <model>` | Claude model (`fable`, `opus`, `sonnet`, `haiku`, or full ID; defaults to `opus`. `fable` passes through to Claude Code. The `opus` and `sonnet` aliases resolve to their 1M-context variants `claude-opus-4-7[1m]` and `claude-sonnet-4-6[1m]`.) |
+| `--model <model>` | Any Claude Code model alias, full model ID, or provider-specific name; defaults to `opus`. Run `/model` in Claude Code to discover options available to your account and provider. |
 | `--effort <level>` | Reasoning effort: `low`, `medium`, `high`, `xhigh`, `max` (default: `xhigh` for opus, `high` for sonnet and fable, unset for haiku) |
 | `--prompt-file <path>` | Read task description from a file |
 

--- a/README.md
+++ b/README.md
@@ -117,18 +117,18 @@ Quick routing rule:
 Standard read-only review of your current work.
 
 ```text
-$cc:review                          # review uncommitted changes (default: opus + xhigh effort)
+$cc:review                          # review uncommitted changes (default: opus + high effort)
 $cc:review --base main              # review branch vs main
 $cc:review --scope branch           # explicitly compare branch tip to base
 $cc:review --background             # run in background, check with $cc:status later
 $cc:review --model sonnet           # switch to sonnet (defaults to high effort)
 $cc:review --model fable            # use Fable (defaults to high effort)
-$cc:review --model opus --effort high   # opus with a lighter effort
+$cc:review --model opus --effort xhigh  # explicitly raise opus effort
 ```
 
 **Flags:** `--base <ref>`, `--scope <auto|working-tree|branch>`, `--wait`, `--background`, `--model <model>`, `--effort <low|medium|high|xhigh|max>`
 
-**Defaults:** model `opus` with `xhigh` effort. Friendly aliases such as `fable`, `opus`, `sonnet`, and `haiku` pass directly to Claude Code, which resolves them for your account and provider. `sonnet` and `fable` default to `high`; `haiku` has no effort setting. Full model IDs and provider-specific names also pass through unchanged and receive no inferred effort. Pass `--model` and `--effort` to override.
+**Defaults:** model `opus` with `high` effort. Friendly aliases `fable`, `opus`, `sonnet`, and `haiku` pass directly to Claude Code, which resolves them for your account and provider; every friendly alias defaults to `high` effort. Full model IDs and provider-specific names also pass through unchanged and receive no inferred effort. Pass `--model` and `--effort` to override.
 
 **Model discovery:** run `/model` in Claude Code to see the models and effort levels available to your current account and provider, then pass the selected alias or full ID to this plugin. The plugin intentionally does not maintain a static model catalog or force `[1m]`; Claude Code owns alias versions, managed restrictions, provider routing, and extended-context eligibility.
 
@@ -175,7 +175,7 @@ $cc:rescue --model sonnet --effort medium investigate the flaky test
 | `--fresh` | Force a new task (don't resume) |
 | `--write` | Allow file edits (default) |
 | `--model <model>` | Any Claude Code model alias, full model ID, or provider-specific name; defaults to `opus`. Run `/model` in Claude Code to discover options available to your account and provider. |
-| `--effort <level>` | Reasoning effort: `low`, `medium`, `high`, `xhigh`, `max` (default: `xhigh` for opus, `high` for sonnet and fable, unset for haiku) |
+| `--effort <level>` | Reasoning effort: `low`, `medium`, `high`, `xhigh`, `max` (default: `high` for every friendly model alias) |
 | `--prompt-file <path>` | Read task description from a file |
 
 **Resume behavior:** If you don't pass `--resume` or `--fresh`, rescue checks for a resumable Claude session and asks once whether to continue or start fresh. Your phrasing guides the recommendation — "continue the last run" → resume, "start over" → fresh.

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ $cc:review --model opus --effort xhigh  # explicitly raise opus effort
 
 **Flags:** `--base <ref>`, `--scope <auto|working-tree|branch>`, `--wait`, `--background`, `--model <model>`, `--effort <low|medium|high|xhigh|max>`
 
-**Defaults:** model `opus` with `high` effort. Friendly aliases `fable`, `opus`, `sonnet`, and `haiku` pass directly to Claude Code, which resolves them for your account and provider; every friendly alias defaults to `high` effort. Full model IDs and provider-specific names also pass through unchanged and receive no inferred effort. Pass `--model` and `--effort` to override.
+**Defaults:** model `opus` with `high` effort. After trimming surrounding whitespace, the friendly aliases `fable`, `opus`, `sonnet`, and `haiku` are matched case-insensitively and canonicalized to lowercase; every friendly alias defaults to `high` effort. Every other `--model` value passes through unchanged for Claude Code to resolve, including full model IDs and provider-specific names, and receives no inferred effort. Pass `--model` and `--effort` to override.
 
 **Model discovery:** run `/model` in Claude Code to see the models and effort levels available to your current account and provider, then pass the selected alias or full ID to this plugin. The plugin intentionally does not maintain a static model catalog or force `[1m]`; Claude Code owns alias versions, managed restrictions, provider routing, and extended-context eligibility.
 

--- a/internal-skills/cli-runtime/runtime.md
+++ b/internal-skills/cli-runtime/runtime.md
@@ -25,7 +25,7 @@ Command selection:
 Routing controls:
 - Treat `--model`, `--effort`, `--resume`, `--resume-last`, `--fresh`, `--prompt-file`, `--view-state`, `--owner-session-id`, and `--job-id` as routing controls, not task text.
 - Leave `--model` and `--effort` unset unless the user explicitly asks for a specific model or effort. The companion command applies these defaults itself: model defaults to `opus`; fable, opus, sonnet, and haiku each default to `high` effort.
-- Forward an explicit `--model` value unchanged. Claude Code owns alias resolution; `/model` is the authoritative picker for the current account and provider.
+- Forward an explicit `--model` value unchanged to the companion. The companion trims surrounding whitespace, canonicalizes the friendly aliases `fable`, `opus`, `sonnet`, and `haiku` to lowercase, then forwards every other `--model` value unchanged to Claude Code. Claude Code owns alias resolution; `/model` is the authoritative picker for the current account and provider.
 - `--view-state on-success` means the user will see this companion result in the current turn, so the companion may mark it viewed on success.
 - `--view-state defer` means the parent is not waiting, so the companion must leave the result unread until the user explicitly checks it.
 - `--owner-session-id <session-id>` is an internal parent-session routing control. Preserve it when present so tracked jobs remain visible to the parent session's `$cc:status` / `$cc:result`.

--- a/internal-skills/cli-runtime/runtime.md
+++ b/internal-skills/cli-runtime/runtime.md
@@ -24,7 +24,7 @@ Command selection:
 
 Routing controls:
 - Treat `--model`, `--effort`, `--resume`, `--resume-last`, `--fresh`, `--prompt-file`, `--view-state`, `--owner-session-id`, and `--job-id` as routing controls, not task text.
-- Leave `--model` and `--effort` unset unless the user explicitly asks for a specific model or effort. The companion command applies these defaults itself: model defaults to `opus`, effort defaults to `xhigh` for opus, `high` for sonnet and fable, and is left unset for haiku.
+- Leave `--model` and `--effort` unset unless the user explicitly asks for a specific model or effort. The companion command applies these defaults itself: model defaults to `opus`; fable, opus, sonnet, and haiku each default to `high` effort.
 - Forward an explicit `--model` value unchanged. Claude Code owns alias resolution; `/model` is the authoritative picker for the current account and provider.
 - `--view-state on-success` means the user will see this companion result in the current turn, so the companion may mark it viewed on success.
 - `--view-state defer` means the parent is not waiting, so the companion must leave the result unread until the user explicitly checks it.

--- a/internal-skills/cli-runtime/runtime.md
+++ b/internal-skills/cli-runtime/runtime.md
@@ -25,6 +25,7 @@ Command selection:
 Routing controls:
 - Treat `--model`, `--effort`, `--resume`, `--resume-last`, `--fresh`, `--prompt-file`, `--view-state`, `--owner-session-id`, and `--job-id` as routing controls, not task text.
 - Leave `--model` and `--effort` unset unless the user explicitly asks for a specific model or effort. The companion command applies these defaults itself: model defaults to `opus`, effort defaults to `xhigh` for opus, `high` for sonnet and fable, and is left unset for haiku.
+- Forward an explicit `--model` value unchanged. Claude Code owns alias resolution; `/model` is the authoritative picker for the current account and provider.
 - `--view-state on-success` means the user will see this companion result in the current turn, so the companion may mark it viewed on success.
 - `--view-state defer` means the parent is not waiting, so the companion must leave the result unread until the user explicitly checks it.
 - `--owner-session-id <session-id>` is an internal parent-session routing control. Preserve it when present so tracked jobs remain visible to the parent session's `$cc:status` / `$cc:result`.

--- a/scripts/claude-companion.mjs
+++ b/scripts/claude-companion.mjs
@@ -10,7 +10,7 @@
  *
  * Adapted from codex-companion.mjs:
  * - Uses claude-cli.mjs instead of app-server/broker
- * - Model aliases and full IDs pass through to Claude Code for resolution
+ * - Friendly model aliases canonicalize to lowercase; other names pass through
  * - Default model when --model is unset: opus
  * - Default effort for friendly model aliases: high
  * - Claude CLI effort values: low, medium, high, xhigh, max

--- a/scripts/claude-companion.mjs
+++ b/scripts/claude-companion.mjs
@@ -12,7 +12,7 @@
  * - Uses claude-cli.mjs instead of app-server/broker
  * - Model aliases and full IDs pass through to Claude Code for resolution
  * - Default model when --model is unset: opus
- * - Default effort by model: opus -> xhigh, sonnet|fable -> high, haiku -> unset
+ * - Default effort for friendly model aliases: high
  * - Claude CLI effort values: low, medium, high, xhigh, max
  * - Legacy effort aliases: none|minimal -> low
  * - Review gate matches upstream setup semantics: Stop hook runs when enabled

--- a/scripts/claude-companion.mjs
+++ b/scripts/claude-companion.mjs
@@ -10,7 +10,7 @@
  *
  * Adapted from codex-companion.mjs:
  * - Uses claude-cli.mjs instead of app-server/broker
- * - MODEL_ALIASES: opus -> claude-opus-4-7[1m], sonnet -> claude-sonnet-4-6[1m], haiku -> claude-haiku-4-5
+ * - Model aliases and full IDs pass through to Claude Code for resolution
  * - Default model when --model is unset: opus
  * - Default effort by model: opus -> xhigh, sonnet|fable -> high, haiku -> unset
  * - Claude CLI effort values: low, medium, high, xhigh, max
@@ -42,7 +42,7 @@ import {
   runClaudeReview,
   runClaudeAdversarialReview,
   cancelClaudeProcess,
-  MODEL_ALIASES,
+  resolveModel,
   resolveEffort,
   resolveDefaultModel,
   resolveDefaultEffort,
@@ -137,9 +137,9 @@ function printUsage() {
     [
       "Usage:",
       "  node scripts/claude-companion.mjs setup [--enable-review-gate|--disable-review-gate] [--json]",
-      "  node scripts/claude-companion.mjs review [--wait|--background] [--base <ref>] [--scope <auto|working-tree|branch>] [--model <model|fable|opus|sonnet|haiku>] [--effort <low|medium|high|xhigh|max>]",
-      "  node scripts/claude-companion.mjs adversarial-review [--wait|--background] [--base <ref>] [--scope <auto|working-tree|branch>] [--model <model|fable|opus|sonnet|haiku>] [--effort <low|medium|high|xhigh|max>] [focus text]",
-      "  node scripts/claude-companion.mjs task [--background] [--write] [--resume-last|--resume|--fresh] [--model <model|fable|opus|sonnet|haiku>] [--effort <low|medium|high|xhigh|max>] [prompt]",
+      "  node scripts/claude-companion.mjs review [--wait|--background] [--base <ref>] [--scope <auto|working-tree|branch>] [--model <model>] [--effort <low|medium|high|xhigh|max>]",
+      "  node scripts/claude-companion.mjs adversarial-review [--wait|--background] [--base <ref>] [--scope <auto|working-tree|branch>] [--model <model>] [--effort <low|medium|high|xhigh|max>] [focus text]",
+      "  node scripts/claude-companion.mjs task [--background] [--write] [--resume-last|--resume|--fresh] [--model <model>] [--effort <low|medium|high|xhigh|max>] [prompt]",
       "  node scripts/claude-companion.mjs status [job-id] [--all] [--json]",
       "  node scripts/claude-companion.mjs result [job-id] [--json]",
       "  node scripts/claude-companion.mjs cancel [job-id] [--json]",
@@ -178,17 +178,6 @@ function redactOutputReplacer(key, value) {
 // ---------------------------------------------------------------------------
 // Normalization
 // ---------------------------------------------------------------------------
-
-function normalizeRequestedModel(model) {
-  if (model == null) {
-    return null;
-  }
-  const normalized = String(model).trim();
-  if (!normalized) {
-    return null;
-  }
-  return MODEL_ALIASES.get(normalized.toLowerCase()) ?? normalized;
-}
 
 function resolveReservedJobFile(workspaceRoot, jobId) {
   const safeJobId = sanitizeId(jobId, "job ID");
@@ -1521,7 +1510,7 @@ async function handleReviewCommand(argv, config) {
     Boolean(options.background)
   );
 
-  const requestedModel = normalizeRequestedModel(options.model);
+  const requestedModel = resolveModel(options.model);
   const resolvedModel = resolveDefaultModel(requestedModel);
   const resolvedEffort = resolveDefaultEffort(resolvedModel, options.effort);
 
@@ -1622,7 +1611,7 @@ async function handleTask(argv) {
   const cwd = resolveCommandCwd(options);
   const workspaceRoot = resolveCommandWorkspace(options);
 
-  const requestedModel = normalizeRequestedModel(options.model);
+  const requestedModel = resolveModel(options.model);
   const model = resolveDefaultModel(requestedModel);
   const resolvedEffort = resolveDefaultEffort(model, options.effort);
   const effort = resolvedEffort ? resolveEffort(resolvedEffort) : null;

--- a/scripts/lib/claude-cli.mjs
+++ b/scripts/lib/claude-cli.mjs
@@ -647,9 +647,10 @@ export const VALID_EFFORTS = new Set(["low", "medium", "high", "xhigh", "max"]);
 export const DEFAULT_MODEL = "opus";
 
 export const DEFAULT_EFFORT_BY_MODEL = new Map([
-  ["opus", "xhigh"],
-  ["sonnet", "high"],
   ["fable", "high"],
+  ["opus", "high"],
+  ["sonnet", "high"],
+  ["haiku", "high"],
 ]);
 
 export function resolveDefaultModel(model) {

--- a/scripts/lib/claude-cli.mjs
+++ b/scripts/lib/claude-cli.mjs
@@ -634,14 +634,8 @@ export function pruneStaleReviewMcpConfigs(options = {}) {
 }
 
 // ---------------------------------------------------------------------------
-// Model & Effort Mapping
+// Model & Effort Selection
 // ---------------------------------------------------------------------------
-
-export const MODEL_ALIASES = new Map([
-  ["opus", "claude-opus-4-7[1m]"],
-  ["sonnet", "claude-sonnet-4-6[1m]"],
-  ["haiku", "claude-haiku-4-5"],
-]);
 
 export const EFFORT_ALIASES = {
   none: "low",
@@ -654,11 +648,7 @@ export const DEFAULT_MODEL = "opus";
 
 export const DEFAULT_EFFORT_BY_MODEL = new Map([
   ["opus", "xhigh"],
-  ["claude-opus-4-7", "xhigh"],
-  ["claude-opus-4-7[1m]", "xhigh"],
   ["sonnet", "high"],
-  ["claude-sonnet-4-6", "high"],
-  ["claude-sonnet-4-6[1m]", "high"],
   ["fable", "high"],
 ]);
 
@@ -678,8 +668,9 @@ export function resolveDefaultEffort(model, effort) {
 }
 
 export function resolveModel(model) {
-  if (!model) return undefined;
-  return MODEL_ALIASES.get(model) ?? model;
+  if (model == null) return undefined;
+  const normalized = String(model).trim();
+  return normalized || undefined;
 }
 
 export function resolveEffort(effort) {

--- a/scripts/lib/claude-cli.mjs
+++ b/scripts/lib/claude-cli.mjs
@@ -646,6 +646,8 @@ export const VALID_EFFORTS = new Set(["low", "medium", "high", "xhigh", "max"]);
 
 export const DEFAULT_MODEL = "opus";
 
+const FRIENDLY_ALIASES = new Set(["fable", "opus", "sonnet", "haiku"]);
+
 export const DEFAULT_EFFORT_BY_MODEL = new Map([
   ["fable", "high"],
   ["opus", "high"],
@@ -671,7 +673,9 @@ export function resolveDefaultEffort(model, effort) {
 export function resolveModel(model) {
   if (model == null) return undefined;
   const normalized = String(model).trim();
-  return normalized || undefined;
+  if (!normalized) return undefined;
+  const canonical = normalized.toLowerCase();
+  return FRIENDLY_ALIASES.has(canonical) ? canonical : normalized;
 }
 
 export function resolveEffort(effort) {

--- a/skills/adversarial-review/SKILL.md
+++ b/skills/adversarial-review/SKILL.md
@@ -18,7 +18,7 @@ Resolve `<plugin-root>` as two directories above this `SKILL.md` file. Always ru
 
 Supported arguments: `--wait`, `--background`, `--base <ref>`, `--scope auto|working-tree|branch`, `--model <model>`, `--effort <low|medium|high|xhigh|max>`, plus optional focus text after the flags (defaults: model=opus; fable, opus, sonnet, and haiku each default to high effort)
 
-Forward `--model` unchanged. Claude Code owns alias resolution; `/model` is the authoritative picker for the current account and provider.
+Forward `--model` unchanged to the companion. The companion trims surrounding whitespace, canonicalizes the friendly aliases `fable`, `opus`, `sonnet`, and `haiku` to lowercase, then forwards every other `--model` value unchanged to Claude Code. Claude Code owns alias resolution; `/model` is the authoritative picker for the current account and provider.
 
 Raw slash-command arguments:
 `$ARGUMENTS`

--- a/skills/adversarial-review/SKILL.md
+++ b/skills/adversarial-review/SKILL.md
@@ -18,6 +18,8 @@ Resolve `<plugin-root>` as two directories above this `SKILL.md` file. Always ru
 
 Supported arguments: `--wait`, `--background`, `--base <ref>`, `--scope auto|working-tree|branch`, `--model <model>`, `--effort <low|medium|high|xhigh|max>`, plus optional focus text after the flags (defaults: model=opus, effort=xhigh; sonnet and fable default to high; haiku has no effort)
 
+Forward `--model` unchanged. Claude Code owns alias resolution; `/model` is the authoritative picker for the current account and provider.
+
 Raw slash-command arguments:
 `$ARGUMENTS`
 

--- a/skills/adversarial-review/SKILL.md
+++ b/skills/adversarial-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: adversarial-review
-description: 'Run a design-challenging Claude Code review of local git changes in this repository. Args: --wait, --background, --base <ref>, --scope <auto|working-tree|branch>, --model <model>, --effort <low|medium|high|xhigh|max>, [focus text]. Defaults to opus + xhigh effort. Use only when the user wants stronger scrutiny than a normal review, such as explicit tradeoff challenge, risky-change review, or custom focus text.'
+description: 'Run a design-challenging Claude Code review of local git changes in this repository. Args: --wait, --background, --base <ref>, --scope <auto|working-tree|branch>, --model <model>, --effort <low|medium|high|xhigh|max>, [focus text]. Defaults to opus + high effort. Use only when the user wants stronger scrutiny than a normal review, such as explicit tradeoff challenge, risky-change review, or custom focus text.'
 ---
 
 # Claude Code Adversarial Review
@@ -16,7 +16,7 @@ Unlike `$cc:review`, this skill accepts custom focus text after the flags. The m
 Resolve `<plugin-root>` as two directories above this `SKILL.md` file. Always run the companion from that active plugin root:
 `node "<plugin-root>/scripts/claude-companion.mjs" adversarial-review ...`
 
-Supported arguments: `--wait`, `--background`, `--base <ref>`, `--scope auto|working-tree|branch`, `--model <model>`, `--effort <low|medium|high|xhigh|max>`, plus optional focus text after the flags (defaults: model=opus, effort=xhigh; sonnet and fable default to high; haiku has no effort)
+Supported arguments: `--wait`, `--background`, `--base <ref>`, `--scope auto|working-tree|branch`, `--model <model>`, `--effort <low|medium|high|xhigh|max>`, plus optional focus text after the flags (defaults: model=opus; fable, opus, sonnet, and haiku each default to high effort)
 
 Forward `--model` unchanged. Claude Code owns alias resolution; `/model` is the authoritative picker for the current account and provider.
 

--- a/skills/rescue/SKILL.md
+++ b/skills/rescue/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: rescue
-description: 'Delegate a substantial diagnosis, implementation, or follow-up task to Claude Code through the tracked-job runtime. Args: --background, --wait, --resume, --resume-last, --fresh, --write, --model <model>, --effort <low|medium|high|xhigh|max>, --prompt-file <path>, [task text]. Defaults to opus + xhigh effort. Use when Claude should investigate or change things, not when the user only wants review findings.'
+description: 'Delegate a substantial diagnosis, implementation, or follow-up task to Claude Code through the tracked-job runtime. Args: --background, --wait, --resume, --resume-last, --fresh, --write, --model <model>, --effort <low|medium|high|xhigh|max>, --prompt-file <path>, [task text]. Defaults to opus + high effort. Use when Claude should investigate or change things, not when the user only wants review findings.'
 ---
 
 # Claude Code Rescue
@@ -24,7 +24,7 @@ Raw slash-command arguments:
 
 Supported arguments: `--background`, `--wait`, `--resume`, `--resume-last`, `--fresh`, `--write`, `--model <model>`, `--effort <low|medium|high|xhigh|max>`, `--prompt-file <path>`, plus free-text task text
 
-Companion defaults: model=opus, effort=xhigh; sonnet and fable default to high; haiku has no effort.
+Companion defaults: model=opus; fable, opus, sonnet, and haiku each default to high effort.
 
 Forward `--model` unchanged. Claude Code owns alias resolution; `/model` is the authoritative picker for the current account and provider.
 

--- a/skills/rescue/SKILL.md
+++ b/skills/rescue/SKILL.md
@@ -26,7 +26,7 @@ Supported arguments: `--background`, `--wait`, `--resume`, `--resume-last`, `--f
 
 Companion defaults: model=opus; fable, opus, sonnet, and haiku each default to high effort.
 
-Forward `--model` unchanged. Claude Code owns alias resolution; `/model` is the authoritative picker for the current account and provider.
+Forward `--model` unchanged to the companion. The companion trims surrounding whitespace, canonicalizes the friendly aliases `fable`, `opus`, `sonnet`, and `haiku` to lowercase, then forwards every other `--model` value unchanged to Claude Code. Claude Code owns alias resolution; `/model` is the authoritative picker for the current account and provider.
 
 Main-thread routing rules:
 - If the user explicitly invoked `$cc:rescue` or `Claude Code Rescue`, do not keep the work in the main Codex thread. Delegate it.

--- a/skills/rescue/SKILL.md
+++ b/skills/rescue/SKILL.md
@@ -26,6 +26,8 @@ Supported arguments: `--background`, `--wait`, `--resume`, `--resume-last`, `--f
 
 Companion defaults: model=opus, effort=xhigh; sonnet and fable default to high; haiku has no effort.
 
+Forward `--model` unchanged. Claude Code owns alias resolution; `/model` is the authoritative picker for the current account and provider.
+
 Main-thread routing rules:
 - If the user explicitly invoked `$cc:rescue` or `Claude Code Rescue`, do not keep the work in the main Codex thread. Delegate it.
 - If the user did not supply a task, ask what Claude Code should investigate or fix.

--- a/skills/review/SKILL.md
+++ b/skills/review/SKILL.md
@@ -18,7 +18,7 @@ Resolve `<plugin-root>` as two directories above this `SKILL.md` file. Always ru
 
 Supported arguments: `--wait`, `--background`, `--base <ref>`, `--scope auto|working-tree|branch`, `--model <model>`, `--effort <low|medium|high|xhigh|max>` (defaults: model=opus; fable, opus, sonnet, and haiku each default to high effort)
 
-Forward `--model` unchanged. Claude Code owns alias resolution; `/model` is the authoritative picker for the current account and provider.
+Forward `--model` unchanged to the companion. The companion trims surrounding whitespace, canonicalizes the friendly aliases `fable`, `opus`, `sonnet`, and `haiku` to lowercase, then forwards every other `--model` value unchanged to Claude Code. Claude Code owns alias resolution; `/model` is the authoritative picker for the current account and provider.
 
 Raw slash-command arguments:
 `$ARGUMENTS`

--- a/skills/review/SKILL.md
+++ b/skills/review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: review
-description: 'Run a standard Claude Code review of local git changes in this repository. Args: --wait, --background, --base <ref>, --scope <auto|working-tree|branch>, --model <model>, --effort <low|medium|high|xhigh|max>. Defaults to opus + xhigh effort. Use as the default path for ordinary code-review requests when the user did not explicitly ask for stronger adversarial scrutiny or for Claude to own the implementation work.'
+description: 'Run a standard Claude Code review of local git changes in this repository. Args: --wait, --background, --base <ref>, --scope <auto|working-tree|branch>, --model <model>, --effort <low|medium|high|xhigh|max>. Defaults to opus + high effort. Use as the default path for ordinary code-review requests when the user did not explicitly ask for stronger adversarial scrutiny or for Claude to own the implementation work.'
 ---
 
 # Claude Code Review
@@ -16,7 +16,7 @@ If the overall request is "you review it too, also ask Claude to review in the b
 Resolve `<plugin-root>` as two directories above this `SKILL.md` file. Always run the companion from that active plugin root:
 `node "<plugin-root>/scripts/claude-companion.mjs" review ...`
 
-Supported arguments: `--wait`, `--background`, `--base <ref>`, `--scope auto|working-tree|branch`, `--model <model>`, `--effort <low|medium|high|xhigh|max>` (defaults: model=opus, effort=xhigh; sonnet and fable default to high; haiku has no effort)
+Supported arguments: `--wait`, `--background`, `--base <ref>`, `--scope auto|working-tree|branch`, `--model <model>`, `--effort <low|medium|high|xhigh|max>` (defaults: model=opus; fable, opus, sonnet, and haiku each default to high effort)
 
 Forward `--model` unchanged. Claude Code owns alias resolution; `/model` is the authoritative picker for the current account and provider.
 

--- a/skills/review/SKILL.md
+++ b/skills/review/SKILL.md
@@ -18,6 +18,8 @@ Resolve `<plugin-root>` as two directories above this `SKILL.md` file. Always ru
 
 Supported arguments: `--wait`, `--background`, `--base <ref>`, `--scope auto|working-tree|branch`, `--model <model>`, `--effort <low|medium|high|xhigh|max>` (defaults: model=opus, effort=xhigh; sonnet and fable default to high; haiku has no effort)
 
+Forward `--model` unchanged. Claude Code owns alias resolution; `/model` is the authoritative picker for the current account and provider.
+
 Raw slash-command arguments:
 `$ARGUMENTS`
 

--- a/tests/claude-cli.test.mjs
+++ b/tests/claude-cli.test.mjs
@@ -478,22 +478,11 @@ describe("resolveDefaultModel", () => {
 });
 
 describe("resolveDefaultEffort", () => {
-  it("defaults to xhigh for the opus alias", () => {
-    assert.equal(resolveDefaultEffort("opus", null), "xhigh");
-    assert.equal(resolveDefaultEffort("OPUS", undefined), "xhigh");
-  });
-
-  it("defaults to high for the sonnet alias", () => {
-    assert.equal(resolveDefaultEffort("sonnet", null), "high");
-  });
-
-  it("defaults to high for the native fable alias", () => {
-    assert.equal(resolveDefaultEffort("fable", null), "high");
-    assert.equal(resolveDefaultEffort("FABLE", undefined), "high");
-  });
-
-  it("returns undefined for haiku (no effort default)", () => {
-    assert.equal(resolveDefaultEffort("haiku", null), undefined);
+  it("defaults to high for every friendly model alias", () => {
+    for (const alias of ["fable", "opus", "sonnet", "haiku"]) {
+      assert.equal(resolveDefaultEffort(alias, null), "high");
+      assert.equal(resolveDefaultEffort(alias.toUpperCase(), undefined), "high");
+    }
   });
 
   it("does not infer effort for full or provider-specific model names", () => {
@@ -511,16 +500,15 @@ describe("resolveDefaultEffort", () => {
   });
 
   it("treats blank effort as missing", () => {
-    assert.equal(resolveDefaultEffort("opus", ""), "xhigh");
-    assert.equal(resolveDefaultEffort("opus", "   "), "xhigh");
+    assert.equal(resolveDefaultEffort("opus", ""), "high");
+    assert.equal(resolveDefaultEffort("opus", "   "), "high");
   });
 
   it("DEFAULT_EFFORT_BY_MODEL contains the expected entries", () => {
-    assert.equal(DEFAULT_EFFORT_BY_MODEL.get("opus"), "xhigh");
-    assert.equal(DEFAULT_EFFORT_BY_MODEL.get("sonnet"), "high");
-    assert.equal(DEFAULT_EFFORT_BY_MODEL.get("fable"), "high");
-    assert.equal(DEFAULT_EFFORT_BY_MODEL.has("haiku"), false);
-    assert.equal(DEFAULT_EFFORT_BY_MODEL.size, 3);
+    for (const alias of ["fable", "opus", "sonnet", "haiku"]) {
+      assert.equal(DEFAULT_EFFORT_BY_MODEL.get(alias), "high");
+    }
+    assert.equal(DEFAULT_EFFORT_BY_MODEL.size, 4);
   });
 });
 

--- a/tests/claude-cli.test.mjs
+++ b/tests/claude-cli.test.mjs
@@ -427,15 +427,24 @@ describe("validateTurnCompletion", () => {
 // ===========================================================================
 
 describe("resolveModel", () => {
-  it("passes Claude Code model aliases through unchanged", () => {
-    for (const alias of ["fable", "opus", "sonnet", "haiku", "default", "opusplan"]) {
+  it("canonicalizes friendly model aliases case-insensitively", () => {
+    for (const alias of ["fable", "opus", "sonnet", "haiku"]) {
       assert.equal(resolveModel(alias), alias);
+      assert.equal(resolveModel(alias.toUpperCase()), alias);
+      assert.equal(resolveModel(`${alias[0].toUpperCase()}${alias.slice(1)}`), alias);
     }
   });
 
-  it("passes full and provider-specific model names through unchanged", () => {
+  it("passes other aliases, full IDs, and provider-specific names through unchanged", () => {
+    for (const alias of ["default", "best", "opusplan", "opus[1m]", "sonnet[1m]"]) {
+      assert.equal(resolveModel(alias), alias);
+    }
     assert.equal(resolveModel("claude-fable-5"), "claude-fable-5");
-    assert.equal(resolveModel("us.anthropic.claude-opus-custom"), "us.anthropic.claude-opus-custom");
+    assert.equal(resolveModel("CLAUDE-FABLE-5"), "CLAUDE-FABLE-5");
+    assert.equal(
+      resolveModel("Us.Anthropic.Claude-Opus-Custom"),
+      "Us.Anthropic.Claude-Opus-Custom"
+    );
   });
 
   it("returns undefined for null/undefined input", () => {
@@ -448,7 +457,8 @@ describe("resolveModel", () => {
     assert.equal(resolveModel("   "), undefined);
   });
 
-  it("trims surrounding whitespace without rewriting the model", () => {
+  it("trims surrounding whitespace before canonicalizing friendly aliases", () => {
+    assert.equal(resolveModel("  OpUs  "), "opus");
     assert.equal(resolveModel("  claude-fable-5  "), "claude-fable-5");
   });
 });

--- a/tests/claude-cli.test.mjs
+++ b/tests/claude-cli.test.mjs
@@ -14,7 +14,6 @@ import {
   resolveDefaultEffort,
   resolveClaudeBin,
   buildArgs,
-  MODEL_ALIASES,
   EFFORT_ALIASES,
   VALID_EFFORTS,
   DEFAULT_MODEL,
@@ -428,20 +427,15 @@ describe("validateTurnCompletion", () => {
 // ===========================================================================
 
 describe("resolveModel", () => {
-  it("maps 'sonnet' to the 1M variant 'claude-sonnet-4-6[1m]'", () => {
-    assert.equal(resolveModel("sonnet"), "claude-sonnet-4-6[1m]");
+  it("passes Claude Code model aliases through unchanged", () => {
+    for (const alias of ["fable", "opus", "sonnet", "haiku", "default", "opusplan"]) {
+      assert.equal(resolveModel(alias), alias);
+    }
   });
 
-  it("maps 'haiku' to 'claude-haiku-4-5'", () => {
-    assert.equal(resolveModel("haiku"), "claude-haiku-4-5");
-  });
-
-  it("passes through unknown model names", () => {
-    assert.equal(resolveModel("claude-3-opus-20240229"), "claude-3-opus-20240229");
-  });
-
-  it("passes the native 'fable' alias through unchanged", () => {
-    assert.equal(resolveModel("fable"), "fable");
+  it("passes full and provider-specific model names through unchanged", () => {
+    assert.equal(resolveModel("claude-fable-5"), "claude-fable-5");
+    assert.equal(resolveModel("us.anthropic.claude-opus-custom"), "us.anthropic.claude-opus-custom");
   });
 
   it("returns undefined for null/undefined input", () => {
@@ -449,20 +443,13 @@ describe("resolveModel", () => {
     assert.equal(resolveModel(undefined), undefined);
   });
 
-  it("passes through empty string", () => {
+  it("returns undefined for blank input", () => {
     assert.equal(resolveModel(""), undefined);
+    assert.equal(resolveModel("   "), undefined);
   });
 
-  it("maps 'opus' to the 1M variant 'claude-opus-4-7[1m]'", () => {
-    assert.equal(resolveModel("opus"), "claude-opus-4-7[1m]");
-  });
-
-  it("MODEL_ALIASES map has expected entries", () => {
-    assert.equal(MODEL_ALIASES.size, 3);
-    assert.ok(MODEL_ALIASES.has("opus"));
-    assert.ok(MODEL_ALIASES.has("sonnet"));
-    assert.ok(MODEL_ALIASES.has("haiku"));
-    assert.equal(MODEL_ALIASES.has("fable"), false);
+  it("trims surrounding whitespace without rewriting the model", () => {
+    assert.equal(resolveModel("  claude-fable-5  "), "claude-fable-5");
   });
 });
 
@@ -491,17 +478,13 @@ describe("resolveDefaultModel", () => {
 });
 
 describe("resolveDefaultEffort", () => {
-  it("defaults to xhigh for opus alias and resolved id (including 1M variant)", () => {
+  it("defaults to xhigh for the opus alias", () => {
     assert.equal(resolveDefaultEffort("opus", null), "xhigh");
-    assert.equal(resolveDefaultEffort("claude-opus-4-7", null), "xhigh");
-    assert.equal(resolveDefaultEffort("claude-opus-4-7[1m]", null), "xhigh");
     assert.equal(resolveDefaultEffort("OPUS", undefined), "xhigh");
   });
 
-  it("defaults to high for sonnet alias and resolved id (including 1M variant)", () => {
+  it("defaults to high for the sonnet alias", () => {
     assert.equal(resolveDefaultEffort("sonnet", null), "high");
-    assert.equal(resolveDefaultEffort("claude-sonnet-4-6", null), "high");
-    assert.equal(resolveDefaultEffort("claude-sonnet-4-6[1m]", null), "high");
   });
 
   it("defaults to high for the native fable alias", () => {
@@ -511,10 +494,12 @@ describe("resolveDefaultEffort", () => {
 
   it("returns undefined for haiku (no effort default)", () => {
     assert.equal(resolveDefaultEffort("haiku", null), undefined);
-    assert.equal(resolveDefaultEffort("claude-haiku-4-5", undefined), undefined);
   });
 
-  it("returns undefined for unknown model when effort not provided", () => {
+  it("does not infer effort for full or provider-specific model names", () => {
+    assert.equal(resolveDefaultEffort("claude-opus-4-7[1m]", null), undefined);
+    assert.equal(resolveDefaultEffort("claude-sonnet-4-6", null), undefined);
+    assert.equal(resolveDefaultEffort("us.anthropic.claude-opus-custom", null), undefined);
     assert.equal(resolveDefaultEffort("some-future-model", null), undefined);
   });
 
@@ -532,13 +517,10 @@ describe("resolveDefaultEffort", () => {
 
   it("DEFAULT_EFFORT_BY_MODEL contains the expected entries", () => {
     assert.equal(DEFAULT_EFFORT_BY_MODEL.get("opus"), "xhigh");
-    assert.equal(DEFAULT_EFFORT_BY_MODEL.get("claude-opus-4-7"), "xhigh");
-    assert.equal(DEFAULT_EFFORT_BY_MODEL.get("claude-opus-4-7[1m]"), "xhigh");
     assert.equal(DEFAULT_EFFORT_BY_MODEL.get("sonnet"), "high");
-    assert.equal(DEFAULT_EFFORT_BY_MODEL.get("claude-sonnet-4-6"), "high");
-    assert.equal(DEFAULT_EFFORT_BY_MODEL.get("claude-sonnet-4-6[1m]"), "high");
     assert.equal(DEFAULT_EFFORT_BY_MODEL.get("fable"), "high");
     assert.equal(DEFAULT_EFFORT_BY_MODEL.has("haiku"), false);
+    assert.equal(DEFAULT_EFFORT_BY_MODEL.size, 3);
   });
 });
 
@@ -740,11 +722,11 @@ describe("buildArgs", () => {
     assert.ok(!args.includes("--no-session-persistence"));
   });
 
-  it("includes --model with resolved model alias", () => {
+  it("includes the model alias unchanged", () => {
     const args = buildArgs("p", { model: "sonnet" });
     const idx = args.indexOf("--model");
     assert.ok(idx >= 0);
-    assert.equal(args[idx + 1], "claude-sonnet-4-6[1m]");
+    assert.equal(args[idx + 1], "sonnet");
   });
 
   it("includes the native fable alias unchanged", () => {

--- a/tests/e2e/codex-skills-e2e.test.mjs
+++ b/tests/e2e/codex-skills-e2e.test.mjs
@@ -1708,7 +1708,7 @@ describe("Codex direct-skill E2E", () => {
       const claudeInvocations = readClaudeInvocations(testEnv.claudeLogFile);
       assert.ok(
         claudeInvocations.some(
-          (entry) => entry.args.includes("--model") && entry.args.includes("claude-haiku-4-5")
+          (entry) => entry.args.includes("--model") && entry.args.includes("haiku")
         ),
         "installed plugin review should forward the requested model alias to Claude without running setup first"
       );
@@ -1759,7 +1759,7 @@ describe("Codex direct-skill E2E", () => {
       assert.match(finalMessage, /Claude Code Review/);
       const claudeInvocations = readClaudeInvocations(testEnv.claudeLogFile);
       assert.ok(
-        claudeInvocations.some((entry) => entry.args.includes("--model") && entry.args.includes("claude-haiku-4-5")),
+        claudeInvocations.some((entry) => entry.args.includes("--model") && entry.args.includes("haiku")),
         "review e2e should forward the requested model alias to Claude"
       );
     } finally {

--- a/tests/integration/claude-companion.test.mjs
+++ b/tests/integration/claude-companion.test.mjs
@@ -954,6 +954,39 @@ describe("claude-companion integration", () => {
     }
   });
 
+  it("defaults every friendly model alias to high effort", () => {
+    const testEnv = createTestEnvironment();
+
+    try {
+      for (const alias of ["fable", "opus", "sonnet", "haiku"]) {
+        const argsFile = path.join(testEnv.rootDir, `${alias}-default-effort-args.json`);
+        runCompanion(
+          [
+            "task",
+            "--cwd",
+            testEnv.workspaceDir,
+            "--model",
+            alias,
+            "--quiet-progress",
+            `${alias} default effort delay=20`,
+          ],
+          {
+            env: {
+              ...testEnv.env,
+              CLAUDE_ARGS_FILE: argsFile,
+            },
+          }
+        );
+
+        const args = JSON.parse(fs.readFileSync(argsFile, "utf8"));
+        assert.equal(args[args.indexOf("--model") + 1], alias);
+        assert.equal(args[args.indexOf("--effort") + 1], "high");
+      }
+    } finally {
+      cleanupTestEnvironment(testEnv);
+    }
+  });
+
   it("passes native Fable with high default effort through task and review flows", () => {
     const testEnv = createTestEnvironment();
 

--- a/tests/integration/claude-companion.test.mjs
+++ b/tests/integration/claude-companion.test.mjs
@@ -960,13 +960,14 @@ describe("claude-companion integration", () => {
     try {
       for (const alias of ["fable", "opus", "sonnet", "haiku"]) {
         const argsFile = path.join(testEnv.rootDir, `${alias}-default-effort-args.json`);
+        const requestedAlias = alias.toUpperCase();
         runCompanion(
           [
             "task",
             "--cwd",
             testEnv.workspaceDir,
             "--model",
-            alias,
+            requestedAlias,
             "--quiet-progress",
             `${alias} default effort delay=20`,
           ],
@@ -987,7 +988,7 @@ describe("claude-companion integration", () => {
     }
   });
 
-  it("passes native Fable with high default effort through task and review flows", () => {
+  it("canonicalizes native Fable with high default effort through task and review flows", () => {
     const testEnv = createTestEnvironment();
 
     try {
@@ -998,7 +999,7 @@ describe("claude-companion integration", () => {
           "--cwd",
           testEnv.workspaceDir,
           "--model",
-          "fable",
+          "FaBlE",
           "--quiet-progress",
           "fable task delay=20",
         ],
@@ -1030,7 +1031,7 @@ describe("claude-companion integration", () => {
             "--scope",
             "working-tree",
             "--model",
-            "fable",
+            "FaBlE",
             ...focusText,
           ],
           {

--- a/tests/integration/claude-companion.test.mjs
+++ b/tests/integration/claude-companion.test.mjs
@@ -942,7 +942,7 @@ describe("claude-companion integration", () => {
       const args = JSON.parse(fs.readFileSync(argsFile, "utf8"));
       assert.equal(args[0], "-p");
       assert.ok(args.includes("--model"));
-      assert.equal(args[args.indexOf("--model") + 1], "claude-haiku-4-5");
+      assert.equal(args[args.indexOf("--model") + 1], "haiku");
       assert.ok(args.includes("--effort"));
       assert.equal(args[args.indexOf("--effort") + 1], "high");
       assert.ok(args.includes("--permission-mode"));
@@ -1117,7 +1117,7 @@ describe("claude-companion integration", () => {
       );
       assert.equal(
         reviewInvocation.args[reviewInvocation.args.indexOf("--model") + 1],
-        "claude-haiku-4-5"
+        "haiku"
       );
       assert.match(reviewInvocation.prompt, /working tree diff/i);
       assert.match(reviewResult.stdout, /Claude Code Review/);
@@ -1211,7 +1211,7 @@ describe("claude-companion integration", () => {
       const invocation = JSON.parse(fs.readFileSync(invocationFile, "utf8"));
       assert.equal(
         invocation.args[invocation.args.indexOf("--model") + 1],
-        "claude-haiku-4-5"
+        "haiku"
       );
       assert.match(invocation.prompt, /focus on command injection/i);
       assert.match(result.stdout, /Adversarial Review/);

--- a/tests/skills-contracts.test.mjs
+++ b/tests/skills-contracts.test.mjs
@@ -16,7 +16,7 @@ function read(relativePath) {
   return fs.readFileSync(path.join(PROJECT_ROOT, relativePath), "utf8");
 }
 
-test("public model contracts document native Fable support", () => {
+test("public model contracts document native Fable support and alias effort policy", () => {
   const contracts = [
     "README.md",
     "skills/review/SKILL.md",
@@ -28,7 +28,13 @@ test("public model contracts document native Fable support", () => {
   for (const contractPath of contracts) {
     const contract = read(contractPath);
     assert.match(contract, /fable/i, `${contractPath} must document Fable`);
-    assert.match(contract, /fable[^\n]*high|high[^\n]*fable/i, `${contractPath} must document Fable's high default effort`);
+    for (const alias of ["fable", "opus", "sonnet", "haiku"]) {
+      assert.match(
+        contract,
+        new RegExp(`${alias}[^\\n]*high|high[^\\n]*${alias}`, "i"),
+        `${contractPath} must document ${alias}'s high default effort`
+      );
+    }
   }
 });
 

--- a/tests/skills-contracts.test.mjs
+++ b/tests/skills-contracts.test.mjs
@@ -50,6 +50,25 @@ test("model contracts delegate discovery and alias resolution to Claude Code", (
   for (const contractPath of contracts) {
     const contract = read(contractPath);
     assert.match(contract, /\/model/i, `${contractPath} must point to Claude Code model discovery`);
+    assert.match(
+      contract,
+      /friendly aliases?[^\n]*lowercase/i,
+      `${contractPath} must document friendly alias canonicalization`
+    );
+    assert.match(
+      contract,
+      /every other `--model` value[^\n]*unchanged/i,
+      `${contractPath} must preserve non-friendly model values`
+    );
+  }
+
+  for (const contractPath of contracts.filter((contractPath) => contractPath !== "README.md")) {
+    const contract = read(contractPath);
+    assert.match(
+      contract,
+      /Forward (?:an explicit )?`--model`(?: value)? unchanged to the companion/i,
+      `${contractPath} must preserve the user's model value until the companion boundary`
+    );
   }
 
   const implementation = [

--- a/tests/skills-contracts.test.mjs
+++ b/tests/skills-contracts.test.mjs
@@ -32,6 +32,29 @@ test("public model contracts document native Fable support", () => {
   }
 });
 
+test("model contracts delegate discovery and alias resolution to Claude Code", () => {
+  const contracts = [
+    "README.md",
+    "skills/review/SKILL.md",
+    "skills/adversarial-review/SKILL.md",
+    "skills/rescue/SKILL.md",
+    "internal-skills/cli-runtime/runtime.md",
+  ];
+
+  for (const contractPath of contracts) {
+    const contract = read(contractPath);
+    assert.match(contract, /\/model/i, `${contractPath} must point to Claude Code model discovery`);
+  }
+
+  const implementation = [
+    read("scripts/claude-companion.mjs"),
+    read("scripts/lib/claude-cli.mjs"),
+  ].join("\n");
+  assert.doesNotMatch(implementation, /MODEL_ALIASES/);
+  assert.doesNotMatch(implementation, /claude-(?:opus|sonnet|haiku)-\d/);
+  assert.doesNotMatch(implementation, /\[1m\]/);
+});
+
 test("built-in child commands preserve the workspace for reserved job ids", () => {
   const skills = [
     ["rescue", "skills/rescue/SKILL.md"],


### PR DESCRIPTION
## Sources and design precedent

- [OpenAI `codex-plugin-cc` stable companion](https://github.com/openai/codex-plugin-cc/blob/db52e28f4d9ded852ab3942cea316258ae4ef346/plugins/codex/scripts/codex-companion.mjs) passes arbitrary model names to Codex and keeps only narrow convenience aliasing.
- [OpenAI stable app-server wrapper](https://github.com/openai/codex-plugin-cc/blob/db52e28f4d9ded852ab3942cea316258ae4ef346/plugins/codex/scripts/lib/codex.mjs) leaves host-resolved model and effort values unset when not requested.
- [Anthropic Claude Code model configuration](https://code.claude.com/docs/en/model-config) assigns alias versions, account defaults, managed model restrictions, provider pins, and extended-context eligibility to Claude Code configuration.
- [Anthropic programmatic usage](https://code.claude.com/docs/en/headless) documents supported headless invocation and resolved session metadata.
- OpenAI [PR #471](https://github.com/openai/codex-plugin-cc/pull/471) and [PR #454](https://github.com/openai/codex-plugin-cc/pull/454) explore dynamic catalogs but remain unmerged; they are research context, not stable precedent.

## OpenAI alignment: host CLI owns model resolution

This PR makes the stable OpenAI boundary front-and-center: the wrapper owns orchestration and a small user-facing default policy, while the host CLI owns evolving model aliases, provider routing, account eligibility, and discovery.

Like OpenAI's reciprocal plugin, `cc-plugin-codex` now forwards arbitrary model aliases and full/provider-specific IDs directly to its host CLI. It removes stale version pins and does not force `[1m]` behavior that depends on account and provider configuration.

## Anthropic alignment

Claude Code `/model` remains the authoritative account/provider-aware picker. Managed model restrictions, provider-specific names, alias versions, and extended-context eligibility stay under Claude Code or administrator control instead of being duplicated in this plugin.

## Stack dependency

Depends on #76. This PR contains that Fable-support commit plus model-delegation and uniform-effort commits. Review only this PR's additional work with the [stack comparison](https://github.com/mychaelconnolly/cc-plugin-codex/compare/agent/fable-support...agent/delegate-model-aliases). After #76 merges, this PR's upstream diff should reduce to those follow-up changes.

## What changed

- Removed fixed Opus, Sonnet, and Haiku model mappings.
- Trimmed and forwarded every explicit model value without rewriting it.
- Standardized implicit effort for friendly aliases: Fable, Opus, Sonnet, and Haiku each default to `high`.
- Kept `opus` as the model used when `--model` is omitted.
- Kept explicit `--effort` authoritative.
- Stopped guessing effort for full or provider-specific model IDs.
- Documented Claude Code `/model` as the authoritative discovery mechanism.
- Updated unit, integration, E2E, and skill-contract expectations for pass-through routing and the uniform alias effort policy.

## Intentional local policy

OpenAI's stable companion leaves omitted model and effort values to Codex. This plugin intentionally keeps a small compatibility policy: omitted model selects the friendly `opus` alias, and every friendly alias defaults to `high` effort. Alignment covers host-owned model resolution; it does not require identical product defaults.

Full and provider-specific IDs remain pure pass-through values with no inferred effort because their supported capabilities can vary by provider and configuration.

## User impact

Claude Code can advance aliases without a plugin release. Users get one predictable `high` effort default across Fable, Opus, Sonnet, and Haiku, while explicit effort settings still win. Users can inspect current model choices with `/model` and pass any listed alias or full ID to the plugin.

## Validation

- `npm run check` — 504 unit tests, 43 integration tests, and 22 E2E tests passed.
- Added integration coverage proving all four friendly aliases reach Claude Code with `--effort high`.
- PR #76's live no-tools Fable smoke remains valid with pass-through routing.
