### PR TITLE
fix: fall back to the liveness probe when the identity probe is denied

### DIFF
--- a/scripts/lib/process.mjs
+++ b/scripts/lib/process.mjs
@@ -155,10 +155,18 @@ export function getProcessIdentity(pid) {
   }
 }
 
-export function validateProcessIdentity(pid, expectedIdentity) {
+export function validateProcessIdentity(pid, expectedIdentity, options = {}) {
+  const identityImpl = options.identityImpl ?? getProcessIdentity;
   try {
-    return getProcessIdentity(pid) === expectedIdentity;
-  } catch {
+    return identityImpl(pid) === expectedIdentity;
+  } catch (error) {
+    // A denied probe (sandboxed `ps`, unreadable /proc entry) means the identity
+    // cannot be established, not that the process is gone. Fall back to the
+    // zero-signal liveness probe, which still reports ESRCH for a dead PID.
+    // PID-reuse detection is only given up when identity is unknowable at all.
+    if (error?.code === "EPERM" || error?.code === "EACCES") {
+      return isProcessAlive(pid, options);
+    }
     return false;
   }
 }

--- a/tests/process.test.mjs
+++ b/tests/process.test.mjs
@@ -387,4 +387,42 @@ describe("validateProcessIdentity", () => {
   it("returns false for non-existent PID", () => {
     assert.equal(validateProcessIdentity(99999999, "any"), false);
   });
+
+  it("falls back to the liveness probe when the identity probe is denied", () => {
+    const deniedIdentity = () => {
+      throw Object.assign(new Error("spawnSync ps EPERM"), { code: "EPERM" });
+    };
+
+    assert.equal(
+      validateProcessIdentity(12345, "recorded-identity", {
+        identityImpl: deniedIdentity,
+        killImpl: () => {
+          throw Object.assign(new Error("operation not permitted"), { code: "EPERM" });
+        },
+      }),
+      true,
+    );
+
+    assert.equal(
+      validateProcessIdentity(12345, "recorded-identity", {
+        identityImpl: deniedIdentity,
+        killImpl: () => {
+          throw Object.assign(new Error("no such process"), { code: "ESRCH" });
+        },
+      }),
+      false,
+    );
+  });
+
+  it("keeps a failed identity probe that is not a denial classified as dead", () => {
+    assert.equal(
+      validateProcessIdentity(12345, "recorded-identity", {
+        identityImpl: () => {
+          throw new Error("ps: exit=1");
+        },
+        killImpl: () => true,
+      }),
+      false,
+    );
+  });
 });


### PR DESCRIPTION
## Summary

`validateProcessIdentity()` collapsed "the probe was denied" into "the process is dead" — the same defect #79 reported for `isProcessAlive()`, at the branch #80 deliberately left alone.

Inside a Codex `workspace-write` sandbox, `spawnSync ps` fails with `EPERM` unconditionally (not only for non-descendants, the way the zero-signal probe does), so `getProcessIdentity()` always throws, the bare `catch` returns `false`, and `reapStaleJobs()` auto-reaps every live job that recorded a `pidIdentity`.

## Why it was latent

`claude-cli.mjs` swallows the identical `ps` failure at spawn time and persists `pidIdentity: null`, so the reaper falls through to `isProcessAlive()` — the branch #80 fixed. That is two independent failures cancelling, not a design, and it breaks as soon as a job is spawned where `ps` is permitted and reaped where it is not.

## Fix

Treat `EPERM`/`EACCES` from the identity probe as "identity is unknowable" and defer to `isProcessAlive(pid)`, which still reports `ESRCH` for a genuinely dead PID. One liveness answer, at the same boundary #80 established:

- genuine identity mismatch → not alive (unchanged)
- absent PID / `ps` exiting non-zero → not alive (unchanged)
- denied probe → whatever the zero-signal probe says

PID-reuse detection is only given up in the case where identity cannot be established at all, which is the alternative the issue itself proposes.

## Validation

- new test fails before the production change (`pass 34`) and passes after (`pass 35`)
- both denial branches covered deterministically via an injected `identityImpl`/`killImpl`, matching the pattern #80 introduced
- unit: 509 passed, 0 failed; lint + typecheck clean

Closes #83

🤖 Generated with [Claude Code](https://claude.com/claude-code)