### PR TITLE
fix: fail turns with terminal permission denials

### DIFF
--- a/scripts/lib/claude-cli.mjs
+++ b/scripts/lib/claude-cli.mjs
@@ -181,6 +181,9 @@ export class StreamParser {
       finalMessage: "",
       structuredOutput: null,
       receivedTerminalEvent: false,
+      terminalSubtype: null,
+      terminalIsError: false,
+      permissionDenialCount: 0,
       unknownEvents: [],
       parseErrors: [],
       unresolvedParseErrors: 0,
@@ -222,6 +225,12 @@ export class StreamParser {
           return this._handleSystemEvent(event);
         case "result":
           this.state.receivedTerminalEvent = true;
+          this.state.terminalSubtype =
+            typeof event.subtype === "string" ? event.subtype : null;
+          this.state.terminalIsError = event.is_error === true;
+          this.state.permissionDenialCount = Array.isArray(event.permission_denials)
+            ? event.permission_denials.length
+            : 0;
           if (event.result) {
             this.state.finalMessage = mergeTerminalResultText(
               this.state.finalMessage,
@@ -360,6 +369,21 @@ function mergeTerminalResultText(existingText, terminalText) {
 export function validateTurnCompletion(state, exitCode) {
   if (exitCode !== 0) {
     return { status: "failed", exitCode };
+  }
+  if (state.permissionDenialCount > 0) {
+    return {
+      status: "failed",
+      warning: `Claude reported ${state.permissionDenialCount} denied tool call(s).`,
+    };
+  }
+  if (
+    state.terminalIsError ||
+    (state.terminalSubtype && state.terminalSubtype !== "success")
+  ) {
+    return {
+      status: "failed",
+      warning: `Claude terminal result reported ${state.terminalSubtype ?? "is_error=true"}.`,
+    };
   }
   if (state.unresolvedParseErrors > 0) {
     return {

--- a/tests/claude-cli.test.mjs
+++ b/tests/claude-cli.test.mjs
@@ -65,6 +65,29 @@ describe("StreamParser", () => {
     assert.equal(parser.state.finalMessage, "");
   });
 
+  it("captures terminal permission denials and error metadata", () => {
+    const parser = new StreamParser();
+    const resultEvent = JSON.stringify({
+      type: "result",
+      subtype: "success",
+      is_error: false,
+      permission_denials: [
+        {
+          tool_name: "Bash",
+          tool_input: { command: "git status --short" },
+        },
+      ],
+      result: "done",
+      session_id: "sess-denied",
+    });
+
+    parser.feed(resultEvent + "\n");
+
+    assert.equal(parser.state.terminalSubtype, "success");
+    assert.equal(parser.state.terminalIsError, false);
+    assert.equal(parser.state.permissionDenialCount, 1);
+  });
+
   it("does not overwrite accumulated deltas with a shorter terminal suffix", () => {
     const parser = new StreamParser();
     const delta = JSON.stringify({
@@ -418,6 +441,38 @@ describe("validateTurnCompletion", () => {
     const state = { receivedTerminalEvent: true, unresolvedParseErrors: 0, unknownEvents: [{ type: "new_type", ts: 1 }] };
     const result = validateTurnCompletion(state, 0);
     assert.equal(result.status, "completed");
+  });
+
+  it("returns failed when Claude denied a tool despite exit code 0", () => {
+    const state = {
+      receivedTerminalEvent: true,
+      unresolvedParseErrors: 0,
+      unknownEvents: [],
+      terminalSubtype: "success",
+      terminalIsError: false,
+      permissionDenialCount: 1,
+    };
+
+    const result = validateTurnCompletion(state, 0);
+
+    assert.equal(result.status, "failed");
+    assert.match(result.warning, /1 denied tool call/u);
+  });
+
+  it("returns failed for an error terminal result despite exit code 0", () => {
+    const state = {
+      receivedTerminalEvent: true,
+      unresolvedParseErrors: 0,
+      unknownEvents: [],
+      terminalSubtype: "error_during_execution",
+      terminalIsError: true,
+      permissionDenialCount: 0,
+    };
+
+    const result = validateTurnCompletion(state, 0);
+
+    assert.equal(result.status, "failed");
+    assert.match(result.warning, /error_during_execution/u);
   });
 });
 


### PR DESCRIPTION
## Goal

Prevent Claude turns with denied tools or terminal execution errors from being reported as successful reviews merely because the CLI process exited with code 0.

## Scope and attribution

This is defensive companion hardening found while investigating a custody review failure. It is not the cause or primary fix for that failure: the denied custody attempt invoked `claude --agent` directly and never entered this plugin. The custody route restoration is tracked separately in palisadeinc/custody#7646.

## Summary

- retain `subtype`, `is_error`, and `permission_denials` from the terminal stream event
- fail turn validation when Claude reports any denied tools or a non-success terminal result
- keep the check at the shared Claude stream boundary so review, adversarial review, task, and hook callers inherit the same behavior

## Failure evidence

Claude Code 2.1.220 can emit a terminal `result` with `subtype: "success"`, non-empty `permission_denials`, and process exit code 0. Before this change, the stream parser discarded the denial metadata and `validateTurnCompletion` reported the turn as completed.

This is fail-closed result handling. It does not widen tool permissions or claim to prevent a model from requesting a disallowed tool.

## Test plan

- [x] `node --test tests/claude-cli.test.mjs` (90 passed)
- [x] `npm run check`
  - 509 unit tests passed
  - 43 integration tests passed
  - 22 E2E tests passed
- [x] live Claude 2.1.220 denial stream matched the handled terminal event shape
- [x] cold structured review approved the exact head with no findings or contract gaps
- [x] Hawkman passed
- [x] Semgrep passed

## Risk

Narrow behavior change: a turn that contains a permission denial or terminal error now fails even if it also produced useful text. Callers must retry with an appropriate explicit tool policy rather than treating a partial result as a valid review.
